### PR TITLE
fix(core): improve merge function type safety and implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# Claude向けインデックス
+
+このドキュメントは、Claudeが効率的にコードベースを理解・操作するためのインデックスです。
+
+## プロジェクト概要
+
+モジュラープロンプトフレームワーク - プロンプトを再利用可能なモジュールとして構築・管理するTypeScriptフレームワーク
+
+## コア機能
+
+### 型定義 (`packages/core/src/types.ts`)
+- `PromptModule<TContext>` - 標準セクションは自動的にSectionElementになる
+- `Element` - 6種類の要素型（Text, Message, Material, Chunk, Section, SubSection）
+- `DynamicContent` - 動的コンテンツ生成（Section/SubSection生成不可）
+- `SectionContent` - 標準セクションの内容型（string | SubSectionElement | DynamicContent）
+
+### マージ (`packages/core/src/merge.ts`)
+- `merge(...modules)` - 複数モジュールの統合
+- 同名サブセクションのitemsを結合
+- createContextは全て実行して結果をマージ（後の値で上書き）
+- 順序制御: 通常要素 → サブセクション
+
+### コンパイル (`packages/core/src/compile.ts`)
+- `compile(module, context)` - 標準セクションを自動的にSectionElementに変換
+- DynamicContentを実行して文字列に変換
+- セクション内の要素を並び替え（通常要素 → サブセクション）
+- セクション分類（instructions/data/output）
+
+## 重要な制約
+
+1. **階層制限**: 最大2階層（Section → SubSection → string）
+2. **動的コンテンツ制約**: DynamicContentはSection/SubSectionを生成不可
+3. **要素順序**: セクション内でも通常要素 → サブセクションの順序
+4. **標準セクション**: 自動的にSectionElementとして処理される
+
+## テスト
+
+- `*.test.ts` - 実装と同階層にユニットテスト配置
+- 包括的なマージ・コンパイルテスト実装済み
+
+## 今後の実装予定
+
+- [ ] `@moduler-prompt/driver` - 各種AIモデルドライバー
+- [ ] `@moduler-prompt/process` - ストリーム処理等のパターン
+- [ ] `@moduler-prompt/presets` - 事前定義モジュール集
+
+## 主要ドキュメント
+
+- [仕様書](./docs/PROMPT_MODULE_SPEC_V2.md)
+- [API](./docs/API.md)
+- [Getting Started](./docs/GETTING_STARTED.md)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - 🎯 **マルチモデル対応**: 様々な生成AIモデルへの統一インターフェース
 - 🚀 **ストリーム処理**: 大規模データの効率的な処理
 - 🛠️ **型安全**: TypeScriptによる完全な型定義
+- 🔀 **柔軟なマージ**: モジュールの再帰的統合と順序制御
 
 ## プロジェクト構造
 
@@ -23,8 +24,11 @@
 
 ## ドキュメント
 
-- [コンセプトと設計思想](./docs/IDEAS.md)
-- [既存実装の分析](./docs/EXISTING_IMPLEMENTATION.md)
+- [はじめに](./docs/GETTING_STARTED.md) - クイックスタートガイド
+- [API リファレンス](./docs/API.md) - 詳細なAPI仕様
+- [仕様書 v2](./docs/PROMPT_MODULE_SPEC_V2.md) - プロンプトモジュール仕様
+- [コンセプトと設計思想](./docs/IDEAS.md) - フレームワークの理念
+- [既存実装の分析](./docs/EXISTING_IMPLEMENTATION.md) - 旧バージョンの分析
 
 ## インストール
 
@@ -34,28 +38,42 @@ npm install @moduler-prompt/core @moduler-prompt/driver
 
 ## 使用例
 
-```javascript
-import { mergePrompts, buildPrompt } from '@moduler-prompt/core';
-import { OpenAIDriver } from '@moduler-prompt/driver/openai';
+```typescript
+import { merge, compile, createContext } from '@moduler-prompt/core';
+import type { PromptModule, ChunkElement } from '@moduler-prompt/core';
 
 // モジュールの定義
-const analysisModule = {
+interface AnalysisContext {
+  sourceCode: string;
+  language: string;
+}
+
+const analysisModule: PromptModule<AnalysisContext> = {
+  createContext: () => ({
+    sourceCode: '',
+    language: 'javascript'
+  }),
+  
   objective: ['コードの品質を分析する'],
   instructions: ['静的解析を実行', 'パフォーマンス問題を特定'],
+  
+  chunks: [
+    (context) => ({
+      type: 'chunk',
+      content: context.sourceCode,
+      partOf: `main.${context.language}`
+    } as ChunkElement)
+  ],
+  
   cue: ['分析結果をJSON形式で出力']
 };
 
-// コンテキストの準備
-const context = {
-  chunks: [{ content: sourceCode, partOf: 'main.js' }]
-};
-
-// プロンプトのビルド
-const prompt = buildPrompt(mergePrompts(analysisModule), context);
-
 // 実行
-const driver = new OpenAIDriver({ model: 'gpt-4' });
-const result = await driver.query(prompt);
+const context = createContext(analysisModule);
+context.sourceCode = 'const example = () => { ... }';
+
+const compiled = compile(analysisModule, context);
+// compiledは instructions, data, output のElement配列を含む
 ```
 
 ## 開発

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,297 @@
+# API リファレンス
+
+## @moduler-prompt/core
+
+### 関数
+
+#### `merge`
+
+複数のプロンプトモジュールをマージします。
+
+```typescript
+function merge<T1, T2>(
+  module1: PromptModule<T1>,
+  module2: PromptModule<T2>
+): PromptModule<T1 | T2>
+
+function merge<T1, T2, T3>(
+  module1: PromptModule<T1>,
+  module2: PromptModule<T2>,
+  module3: PromptModule<T3>
+): PromptModule<T1 | T2 | T3>
+
+function merge(...modules: PromptModule<any>[]): PromptModule<any>
+```
+
+**特徴:**
+- 同名のサブセクションのitemsを結合
+- 要素の順序: 通常要素 → サブセクション
+- `createContext`は全て実行されて結果がマージされる（後の値で上書き）
+- Context型はユニオン型になる
+
+**例:**
+```typescript
+const module1: PromptModule = {
+  objective: ['Task 1'],
+  instructions: [{
+    type: 'subsection',
+    title: 'Algorithm',
+    items: ['Step 1']
+  }]
+};
+
+const module2: PromptModule = {
+  objective: ['Task 2'],
+  instructions: [{
+    type: 'subsection',
+    title: 'Algorithm',
+    items: ['Step 2']
+  }]
+};
+
+const merged = merge(module1, module2);
+// merged.objective = ['Task 1', 'Task 2']
+// merged.instructions = [文字列要素, { type: 'subsection', title: 'Algorithm', items: ['Step 1', 'Step 2'] }]
+```
+
+#### `compile`
+
+プロンプトモジュールとコンテキストをコンパイルして、Element配列を生成します。
+
+```typescript
+function compile<TContext = Context>(
+  module: PromptModule<TContext>,
+  context: TContext
+): CompiledPrompt
+
+interface CompiledPrompt {
+  instructions: Element[];
+  data: Element[];
+  output: Element[];
+}
+```
+
+**特徴:**
+- 標準セクションを自動的にSectionElementに変換
+- DynamicContentを実行して結果を文字列に変換
+- セクション内の要素を並び替え（通常要素 → サブセクション）
+- セクションタイプ（instructions/data/output）に応じて分類
+
+**例:**
+```typescript
+const module: PromptModule<{ value: string }> = {
+  objective: ['Process data'],
+  state: [
+    (context) => ({
+      type: 'text',
+      content: `Value: ${context.value}`
+    })
+  ]
+};
+
+const compiled = compile(module, { value: 'test' });
+// compiled.instructions[0] = { type: 'section', title: 'Objective and Role', items: ['Process data'] }
+// compiled.data[0] = { type: 'section', title: 'Current State', items: ['Value: test'] }
+```
+
+#### `createContext`
+
+モジュールのcreateContext関数を使用してコンテキストを作成します。
+
+```typescript
+function createContext<TContext = Context>(
+  module: PromptModule<TContext>
+): TContext
+```
+
+**例:**
+```typescript
+const module: PromptModule<{ initialized: boolean }> = {
+  createContext: () => ({ initialized: true }),
+  objective: ['Task']
+};
+
+const context = createContext(module);
+// context = { initialized: true }
+```
+
+### 型定義
+
+#### `PromptModule<TContext>`
+
+プロンプトモジュールの定義。
+
+```typescript
+interface PromptModule<TContext = any> {
+  // Context生成
+  createContext?: () => TContext;
+  
+  // Instructions セクション（自動的にSectionElementになる）
+  objective?: SectionContent<TContext>;
+  terms?: SectionContent<TContext>;
+  processing?: SectionContent<TContext>;
+  instructions?: SectionContent<TContext>;
+  guidelines?: SectionContent<TContext>;
+  preparationNote?: SectionContent<TContext>;
+  
+  // Data セクション（自動的にSectionElementになる）
+  state?: SectionContent<TContext>;
+  materials?: SectionContent<TContext>;
+  chunks?: SectionContent<TContext>;
+  messages?: SectionContent<TContext>;
+  
+  // Output セクション（自動的にSectionElementになる）
+  cue?: SectionContent<TContext>;
+  schema?: SectionContent<TContext>;
+}
+
+// セクションコンテンツ型
+type SectionContent<TContext = any> = 
+  (string | SubSectionElement | DynamicContent<TContext>)[];
+```
+
+#### Element型
+
+6種類の要素型が定義されています。
+
+##### `TextElement`
+```typescript
+interface TextElement {
+  type: 'text';
+  content: string;
+}
+```
+
+##### `MessageElement`
+```typescript
+interface MessageElement {
+  type: 'message';
+  content: string | Attachment[];
+  role: 'system' | 'assistant' | 'user';
+  name?: string;
+}
+```
+
+##### `MaterialElement`
+```typescript
+interface MaterialElement {
+  type: 'material';
+  content: string | Attachment[];
+  id: string;
+  title: string;
+  usage?: number;
+}
+```
+
+##### `ChunkElement`
+```typescript
+interface ChunkElement {
+  type: 'chunk';
+  content: string | Attachment[];
+  partOf: string;
+  index?: number;
+  usage?: number;
+}
+```
+
+##### `SectionElement`
+```typescript
+interface SectionElement<TContext = any> {
+  type: 'section';
+  content: string;
+  title: string;
+  items: (string | SubSectionElement | DynamicContent<TContext>)[];
+}
+```
+
+##### `SubSectionElement`
+```typescript
+interface SubSectionElement {
+  type: 'subsection';
+  content: string;
+  title: string;
+  items: string[];  // 文字列のみ
+}
+```
+
+#### `DynamicContent<TContext>`
+
+動的にコンテンツを生成する関数。
+
+```typescript
+type DynamicContent<TContext = any> = (
+  context: TContext
+) => DynamicElement[] | DynamicElement | null;
+
+// DynamicElementはSection/SubSectionを除くElement
+type DynamicElement = 
+  | TextElement
+  | MessageElement
+  | MaterialElement
+  | ChunkElement;
+```
+
+**制約:**
+- Section/SubSectionElementは生成できない
+- nullを返すと何も追加されない
+
+#### 標準セクション定義
+
+```typescript
+const STANDARD_SECTIONS = {
+  // Instructions
+  objective: { type: 'instructions' as const, title: 'Objective and Role' },
+  terms: { type: 'instructions' as const, title: 'Term Explanations' },
+  processing: { type: 'instructions' as const, title: 'Processing Algorithm' },
+  instructions: { type: 'instructions' as const, title: 'Instructions' },
+  guidelines: { type: 'instructions' as const, title: 'Guidelines' },
+  preparationNote: { type: 'instructions' as const, title: 'Response Preparation Note' },
+  
+  // Data
+  state: { type: 'data' as const, title: 'Current State' },
+  materials: { type: 'data' as const, title: 'Prepared Materials' },
+  chunks: { type: 'data' as const, title: 'Input Chunks' },
+  messages: { type: 'data' as const, title: 'Messages' },
+  
+  // Output
+  cue: { type: 'output' as const, title: 'Output' },
+  schema: { type: 'output' as const, title: 'Output Schema' }
+} as const;
+```
+
+### 便利な型定義（再利用可能）
+
+これらの型は強制されませんが、共通的な用途で利用できます。
+
+```typescript
+interface ContentWithUsage {
+  content: string;
+  usage: number;
+}
+
+interface Material extends ContentWithUsage {
+  id: string;
+  title: string;
+  attachments?: Attachment[];
+}
+
+interface Chunk extends ContentWithUsage {
+  partOf: string;
+  attachments?: Attachment[];
+}
+
+interface Message {
+  content: string;
+  role: 'system' | 'assistant' | 'user';
+  usage?: number;
+  name?: string;
+  attachments?: Attachment[];
+}
+
+interface Attachment {
+  type: 'text' | 'image_url' | 'file';
+  text?: string;
+  image_url?: { url: string };
+  file?: { path: string; mime_type: string };
+}
+```

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,0 +1,387 @@
+# はじめに - Moduler Prompt
+
+このガイドでは、Moduler Promptフレームワークの基本的な使い方を説明します。
+
+## インストール
+
+```bash
+npm install @moduler-prompt/core
+```
+
+## 基本概念
+
+### 1. PromptModule
+
+プロンプトモジュールは、AIへの指示を構造化したオブジェクトです：
+
+```typescript
+import type { PromptModule } from '@moduler-prompt/core';
+
+const myModule: PromptModule = {
+  objective: ['タスクを実行する'],
+  instructions: ['手順1', '手順2'],
+  cue: ['結果を出力']
+};
+```
+
+### 2. Context
+
+各モジュールは独自のContext型を定義できます：
+
+```typescript
+interface MyContext {
+  userName: string;
+  taskId: number;
+}
+
+const myModule: PromptModule<MyContext> = {
+  createContext: () => ({
+    userName: 'Alice',
+    taskId: 123
+  }),
+  
+  objective: [
+    (context) => ({
+      type: 'text',
+      content: `${context.userName}のタスク#${context.taskId}を処理`
+    })
+  ]
+};
+```
+
+### 3. Element
+
+プロンプトの構成要素には6つの型があります：
+
+- **TextElement**: シンプルなテキスト
+- **MessageElement**: ロール付きメッセージ
+- **MaterialElement**: 参考資料
+- **ChunkElement**: 分割されたテキスト
+- **SectionElement**: セクション（箇条書き）
+- **SubSectionElement**: サブセクション
+
+## 基本的な使い方
+
+### シンプルな例
+
+```typescript
+import { compile, createContext } from '@moduler-prompt/core';
+import type { PromptModule } from '@moduler-prompt/core';
+
+// 1. モジュールを定義
+const analysisModule: PromptModule = {
+  objective: ['コードを分析する'],
+  instructions: [
+    '構文エラーをチェック',
+    'パフォーマンス問題を特定'
+  ],
+  cue: ['分析結果をJSON形式で出力']
+};
+
+// 2. コンテキストを作成
+const context = createContext(analysisModule);
+
+// 3. コンパイル
+const compiled = compile(analysisModule, context);
+
+console.log(compiled.instructions); // objective + instructions
+console.log(compiled.output);       // cue
+```
+
+### 動的コンテンツ
+
+コンテキストに基づいて動的にコンテンツを生成：
+
+```typescript
+interface TaskContext {
+  tasks: string[];
+  priority: 'high' | 'medium' | 'low';
+}
+
+const taskModule: PromptModule<TaskContext> = {
+  createContext: () => ({
+    tasks: [],
+    priority: 'medium'
+  }),
+  
+  objective: ['タスクを処理する'],
+  
+  state: [
+    (context) => ({
+      type: 'text',
+      content: `優先度: ${context.priority}`
+    }),
+    (context) => context.tasks.map(task => ({
+      type: 'text',
+      content: `- ${task}`
+    }))
+  ]
+};
+
+// 使用時
+const context = createContext(taskModule);
+context.tasks = ['タスクA', 'タスクB'];
+context.priority = 'high';
+
+const compiled = compile(taskModule, context);
+```
+
+### セクションとサブセクション
+
+階層構造を持つコンテンツ：
+
+```typescript
+import type { SubSectionElement } from '@moduler-prompt/core';
+
+const structuredModule: PromptModule = {
+  // processing自体が "Processing Algorithm" セクションになる
+  processing: [
+    '入力データを検証',
+    '前処理を実行',
+    '後述の「変換処理」を実行',
+    {
+      type: 'subsection',
+      content: '',
+      title: '変換処理',
+      items: [
+        'データを正規化',
+        '特徴量を抽出',
+        'ベクトル化'
+      ]
+    } as SubSectionElement,
+    '結果を出力'
+  ]
+};
+
+// コンパイル時に以下のような構造になる：
+// ## Processing Algorithm
+// - 入力データを検証
+// - 前処理を実行
+// - 後述の「変換処理」を実行
+// - 結果を出力
+// ### 変換処理  （サブセクションは最後に配置）
+//   - データを正規化
+//   - 特徴量を抽出
+//   - ベクトル化
+```
+
+## モジュールのマージ
+
+複数のモジュールを統合：
+
+```typescript
+import { merge } from '@moduler-prompt/core';
+
+const baseModule: PromptModule = {
+  objective: ['基本タスク'],
+  instructions: ['共通手順']
+};
+
+const extensionModule: PromptModule = {
+  objective: ['追加タスク'],
+  instructions: ['特別な手順']
+};
+
+// マージ
+const mergedModule = merge(baseModule, extensionModule);
+// mergedModule.objective = ['基本タスク', '追加タスク']
+// mergedModule.instructions = ['共通手順', '特別な手順']
+```
+
+### 同名サブセクションのマージ
+
+```typescript
+const module1: PromptModule = {
+  instructions: [
+    {
+      type: 'subsection',
+      content: '',
+      title: 'データ処理',
+      items: ['ステップ1', 'ステップ2']
+    } as SubSectionElement
+  ]
+};
+
+const module2: PromptModule = {
+  instructions: [
+    {
+      type: 'subsection',
+      content: '',
+      title: 'データ処理',  // 同じタイトル
+      items: ['ステップ3']
+    } as SubSectionElement
+  ]
+};
+
+const merged = merge(module1, module2);
+// サブセクションのitemsが結合される：
+// ['ステップ1', 'ステップ2', 'ステップ3']
+```
+
+## 実践的な例
+
+### チャット対話モジュール
+
+```typescript
+import type { PromptModule, MessageElement } from '@moduler-prompt/core';
+
+interface ChatContext {
+  messages: Array<{
+    role: 'user' | 'assistant';
+    content: string;
+  }>;
+  systemPrompt: string;
+}
+
+const chatModule: PromptModule<ChatContext> = {
+  createContext: () => ({
+    messages: [],
+    systemPrompt: 'あなたは親切なアシスタントです'
+  }),
+  
+  objective: [
+    (context) => ({
+      type: 'text',
+      content: context.systemPrompt
+    })
+  ],
+  
+  messages: [
+    (context) => context.messages.map(msg => ({
+      type: 'message',
+      content: msg.content,
+      role: msg.role
+    } as MessageElement))
+  ],
+  
+  cue: ['ユーザーの質問に答えてください']
+};
+
+// 使用例
+const context = createContext(chatModule);
+context.messages = [
+  { role: 'user', content: 'こんにちは' },
+  { role: 'assistant', content: 'こんにちは！' },
+  { role: 'user', content: '今日の天気は？' }
+];
+
+const compiled = compile(chatModule, context);
+```
+
+### ドキュメント処理モジュール
+
+```typescript
+import type { PromptModule, ChunkElement } from '@moduler-prompt/core';
+
+interface DocContext {
+  documentName: string;
+  chunks: Array<{
+    content: string;
+    pageNumber: number;
+  }>;
+}
+
+const docModule: PromptModule<DocContext> = {
+  createContext: () => ({
+    documentName: '',
+    chunks: []
+  }),
+  
+  objective: ['ドキュメントを要約する'],
+  
+  chunks: [
+    (context) => context.chunks.map((chunk, index) => ({
+      type: 'chunk',
+      content: chunk.content,
+      partOf: context.documentName,
+      index: index,
+      usage: chunk.content.length
+    } as ChunkElement))
+  ],
+  
+  instructions: [
+    '各ページの要点を抽出',
+    '全体の要約を作成'
+  ],
+  
+  schema: [
+    {
+      type: 'text',
+      content: JSON.stringify({
+        summary: 'string',
+        keyPoints: ['string'],
+        pageCount: 'number'
+      }, null, 2)
+    }
+  ]
+};
+```
+
+## 重要な制約
+
+### 1. DynamicContentの制限
+
+動的コンテンツ（関数）はSection/SubSectionElementを生成できません：
+
+```typescript
+// ❌ これはできません
+const badModule: PromptModule = {
+  instructions: [
+    (context) => ({
+      type: 'section',  // エラー: DynamicContentはSectionを作れない
+      title: 'Dynamic Section',
+      items: []
+    })
+  ]
+};
+
+// ✅ 静的に定義する必要があります
+const goodModule: PromptModule = {
+  instructions: [
+    {
+      type: 'section',
+      content: '',
+      title: 'Static Section',
+      items: [
+        // itemsの中身は動的に生成可能
+        (context) => 'Dynamic item'
+      ]
+    } as SectionElement
+  ]
+};
+```
+
+### 2. 階層の制限
+
+最大2階層まで（Section → SubSection → string）：
+
+```typescript
+// ✅ 正しい階層（標準セクションは自動的にSectionElementになる）
+const validModule: PromptModule = {
+  instructions: [
+    'Item 1',
+    {
+      type: 'subsection',
+      content: '',
+      title: 'SubSection',
+      items: ['SubItem 1', 'SubItem 2']  // 文字列のみ
+    } as SubSectionElement
+  ]
+};
+// コンパイル後：
+// instructions[0] = {
+//   type: 'section',
+//   title: 'Instructions',
+//   items: ['Item 1', { type: 'subsection', ... }]
+// }
+```
+
+## 次のステップ
+
+- [API リファレンス](./API.md) - 詳細なAPI仕様
+- [仕様書 v2](./PROMPT_MODULE_SPEC_V2.md) - 設計思想と詳細仕様
+- [コンセプト](./IDEAS.md) - フレームワークの理念
+
+## サンプルコード
+
+より多くの例は[GitHubリポジトリ](https://github.com/otolab/moduler-prompt)をご覧ください。

--- a/docs/PROMPT_MODULE_SPEC_V2.md
+++ b/docs/PROMPT_MODULE_SPEC_V2.md
@@ -9,108 +9,102 @@
 
 ### 3つの大分類
 
-プロンプトは3つの主要セクションで構成されます：
+プロンプトは3つの主要カテゴリで構成されます：
 
 1. **Instructions（指示）**: AIへの指示・役割・処理手順
 2. **Data（データ）**: 処理対象となる情報・参考資料
 3. **Output（出力）**: 期待される出力形式・構造
 
-### セクション定義
+### 標準セクション
+
+フレームワークが提供する標準セクションは、自動的にSectionElementとして扱われます：
 
 ```typescript
-interface SectionDefinition {
-  name: string;
-  type: 'instructions' | 'data' | 'output';
-  title: string;
-}
-
-// フレームワークが提供する標準セクション
-const standardSections: SectionDefinition[] = [
-  // Instructions セクション
-  { name: 'objective', type: 'instructions', title: 'Objective and Role' },
-  { name: 'terms', type: 'instructions', title: 'Term Explanations' },
-  { name: 'processing', type: 'instructions', title: 'Processing Algorithm' }, // 新規追加
-  { name: 'instructions', type: 'instructions', title: 'Instructions' },
-  { name: 'guidelines', type: 'instructions', title: 'Guidelines' }, // advicesから統一
-  { name: 'preparationNote', type: 'instructions', title: 'Response Preparation Note' },
+// 標準セクション定義
+const standardSections = {
+  // Instructions
+  objective: { type: 'instructions', title: 'Objective and Role' },
+  terms: { type: 'instructions', title: 'Term Explanations' },
+  processing: { type: 'instructions', title: 'Processing Algorithm' },
+  instructions: { type: 'instructions', title: 'Instructions' },
+  guidelines: { type: 'instructions', title: 'Guidelines' },
+  preparationNote: { type: 'instructions', title: 'Response Preparation Note' },
   
-  // Data セクション
-  { name: 'state', type: 'data', title: 'Current State' },
-  { name: 'materials', type: 'data', title: 'Prepared Materials' },
-  { name: 'chunks', type: 'data', title: 'Input Chunks' },
-  { name: 'messages', type: 'data', title: 'Messages' },
+  // Data
+  state: { type: 'data', title: 'Current State' },
+  materials: { type: 'data', title: 'Prepared Materials' },
+  chunks: { type: 'data', title: 'Input Chunks' },
+  messages: { type: 'data', title: 'Messages' },
   
-  // Output セクション
-  { name: 'cue', type: 'output', title: 'Output' },
-  { name: 'schema', type: 'output', title: 'Output Schema' } // 新規追加
-];
+  // Output
+  cue: { type: 'output', title: 'Output' },
+  schema: { type: 'output', title: 'Output Schema' }
+};
 ```
 
 ## Element（要素）の定義
 
-ChunkItemから名称変更し、型付けされた要素として再定義します。
-
-### 基本インターフェース
+### 基本要素型
 
 ```typescript
-// 基底となるElement型
-interface BaseElement {
-  type: string;
-  content: string | Attachment[];
+// テキスト要素
+interface TextElement {
+  type: 'text';
+  content: string;
 }
 
 // メッセージ要素
-interface MessageElement extends BaseElement {
+interface MessageElement {
   type: 'message';
+  content: string | Attachment[];
   role: 'system' | 'assistant' | 'user';
   name?: string;
 }
 
 // 資料要素
-interface MaterialElement extends BaseElement {
+interface MaterialElement {
   type: 'material';
+  content: string | Attachment[];
   id: string;
   title: string;
   usage?: number;
 }
 
 // 分割テキスト要素
-interface ChunkElement extends BaseElement {
+interface ChunkElement {
   type: 'chunk';
-  partOf: string;  // 元のファイル名やドキュメント名
-  index?: number;  // 分割順序
+  content: string | Attachment[];
+  partOf: string;
+  index?: number;
   usage?: number;
 }
 
-// テキスト要素（シンプルなテキスト）
-interface TextElement extends BaseElement {
-  type: 'text';
-}
-
 // セクション要素（第1階層）
-interface SectionElement extends BaseElement {
+interface SectionElement<TContext = any> {
   type: 'section';
+  content: string;  // セクション自体の説明（通常は空文字列）
   title: string;
-  items: (string | SubSectionElement)[];  // 文字列またはサブセクションの箇条書き
+  items: (string | SubSectionElement | DynamicContent<TContext>)[];
 }
 
 // サブセクション要素（第2階層）
-interface SubSectionElement extends BaseElement {
+interface SubSectionElement {
   type: 'subsection';
+  content: string;  // サブセクション自体の説明（通常は空文字列）
   title: string;
-  items: string[];  // 文字列の箇条書きのみ
+  items: string[];
 }
 
 // 統合型
 type Element = 
+  | TextElement
   | MessageElement 
   | MaterialElement 
   | ChunkElement 
-  | TextElement 
   | SectionElement
   | SubSectionElement;
 
-// Attachment定義（メディア対応）
+// Attachment定義
 interface Attachment {
   type: 'text' | 'image_url' | 'file';
   text?: string;
@@ -122,18 +116,15 @@ interface Attachment {
 ### 動的コンテンツ
 
 ```typescript
-// 動的に生成できる要素の型（SectionElement, SubSectionElementは除外）
+// 動的に生成できる要素（構造要素は除外）
 type DynamicElement = 
+  | TextElement
   | MessageElement 
   | MaterialElement 
-  | ChunkElement 
-  | TextElement;
+  | ChunkElement;
 
 // コンテキストに基づいて動的に要素を生成
-type DynamicContent = (context: Context) => DynamicElement[] | DynamicElement | null;
-
-// プロンプトモジュールでの使用
-type ModuleContent = (string | Element | DynamicContent)[];
+type DynamicContent<TContext> = (context: TContext) => DynamicElement[] | DynamicElement | null;
 ```
 
 ## PromptModule の定義
@@ -143,76 +134,82 @@ interface PromptModule<TContext = any> {
   // コンテキストの生成
   createContext?: () => TContext;
   
-  // Instructions セクション
-  objective?: ModuleContent;
-  terms?: ModuleContent;
-  processing?: ModuleContent;  // 新規: アルゴリズム定義（instructionsより上位）
-  instructions?: ModuleContent;
-  guidelines?: ModuleContent;
-  preparationNote?: ModuleContent;
+  // Instructions セクション（自動的にSectionElementになる）
+  objective?: (string | SubSectionElement | DynamicContent<TContext>)[];
+  terms?: (string | SubSectionElement | DynamicContent<TContext>)[];
+  processing?: (string | SubSectionElement | DynamicContent<TContext>)[];
+  instructions?: (string | SubSectionElement | DynamicContent<TContext>)[];
+  guidelines?: (string | SubSectionElement | DynamicContent<TContext>)[];
+  preparationNote?: (string | SubSectionElement | DynamicContent<TContext>)[];
   
-  // Data セクション
-  state?: ModuleContent;
-  materials?: ModuleContent;
-  chunks?: ModuleContent;
-  messages?: ModuleContent;
+  // Data セクション（自動的にSectionElementになる）
+  state?: (string | SubSectionElement | DynamicContent<TContext>)[];
+  materials?: (string | SubSectionElement | DynamicContent<TContext>)[];
+  chunks?: (string | SubSectionElement | DynamicContent<TContext>)[];
+  messages?: (string | SubSectionElement | DynamicContent<TContext>)[];
   
-  // Output セクション
-  cue?: ModuleContent;
-  schema?: ModuleContent;  // 新規: 出力スキーマ定義
+  // Output セクション（自動的にSectionElementになる）
+  cue?: (string | SubSectionElement | DynamicContent<TContext>)[];
+  schema?: (string | SubSectionElement | DynamicContent<TContext>)[];
 }
+```
+
+### 標準セクションの自動変換
+
+標準セクションに指定された内容は、コンパイル時に自動的にSectionElementとして処理されます：
+
+```typescript
+// 入力（簡潔な記法）
+const module: PromptModule = {
+  processing: [
+    '入力データを検証',
+    '前処理を実行',
+    {
+      type: 'subsection',
+      content: '',
+      title: '変換処理',
+      items: ['データを正規化', '特徴量を抽出']
+    } as SubSectionElement
+  ]
+};
+
+// コンパイル後の出力
+// ## Processing Algorithm
+// - 入力データを検証
+// - 前処理を実行
+// ### 変換処理
+//   - データを正規化
+//   - 特徴量を抽出
 ```
 
 ## Context の定義
 
-Contextは各PromptModuleが自由に定義します。Coreフレームワークは、Contextという概念が存在することのみを定義します。
+各PromptModuleは独自のContext型を定義します：
 
 ```typescript
-// Coreでは型を定義しない（anyまたはunknown）
-type Context = any;
-
-// 各モジュールが独自のContext型を定義
+// 各モジュールが独自に定義
 interface StreamingContext {
-  state: ContentWithUsage;
-  chunks: Chunk[];
+  state: { content: string; usage: number };
+  chunks: Array<{
+    content: string;
+    partOf: string;
+    usage: number;
+  }>;
   range: { start: number; end: number };
-  iteration: {
-    current: number;
-    total?: number;
-    isFirst: boolean;
-    isLast: boolean;
-  };
 }
 
 interface DialogueContext {
-  messages: Message[];
-  materials?: Material[];
-  targetTokens?: number;
-}
-
-// 汎用的な型定義（各モジュールで再利用可能）
-interface ContentWithUsage {
-  content: string;
-  usage: number;
-}
-
-interface Material extends ContentWithUsage {
-  id: string;
-  title: string;
-  attachments?: Attachment[];
-}
-
-interface Chunk extends ContentWithUsage {
-  partOf: string;
-  attachments?: Attachment[];
-}
-
-interface Message {
-  content: string;
-  role: 'system' | 'assistant' | 'user';
-  usage?: number;
-  name?: string;
-  attachments?: Attachment[];
+  messages: Array<{
+    content: string;
+    role: 'system' | 'assistant' | 'user';
+    name?: string;
+  }>;
+  materials?: Array<{
+    id: string;
+    title: string;
+    content: string;
+    usage: number;
+  }>;
 }
 ```
 
@@ -220,120 +217,21 @@ interface Message {
 
 ### 1. モジュールのマージ
 
+複数のモジュールを統合する際の動作：
+
 ```typescript
-function merge<T1, T2>( 
-  module1: PromptModule<T1>,
-  module2: PromptModule<T2>
-): PromptModule<T1 | T2> {
-  return {
-    // Context型はユニオン型になる
-    createContext: () => {
-      // 実装時の判断に委ねる
-      // 最初のモジュールのcreateContextを使用、など
-      if (module1.createContext) return module1.createContext();
-      if (module2.createContext) return module2.createContext();
-      return {} as T1 | T2;
-    },
-    
-    // セクションごとにマージ戦略を適用
-    objective: mergeSection(module1.objective, module2.objective),
-    // ... 他のセクション
-  };
-}
-
-// セクションのマージ戦略
-function mergeSection(
-  section1?: ModuleContent,
-  section2?: ModuleContent
-): ModuleContent | undefined {
-  if (!section1) return section2;
-  if (!section2) return section1;
-  
-  const merged: ModuleContent = [];
-  const subsections: Map<string, SubSectionElement> = new Map();
-  const sections: Map<string, SectionElement> = new Map();
-  const plainItems: (string | Element | DynamicContent)[] = [];
-  
-  // 両セクションの要素を分類
-  for (const item of [...section1, ...section2]) {
-    if (typeof item === 'function') {
-      // DynamicContent（関数）はそのまま保持
-      plainItems.push(item);
-    } else if (typeof item === 'object' && 'type' in item) {
-      if (item.type === 'subsection') {
-        const existing = subsections.get(item.title);
-        if (existing) {
-          // 同名のサブセクションは再帰的にマージ
-          subsections.set(item.title, {
-            ...item,
-            items: [...existing.items, ...item.items]
-          });
-        } else {
-          subsections.set(item.title, item);
-        }
-      } else if (item.type === 'section') {
-        const existing = sections.get(item.title);
-        if (existing) {
-          // 同名のセクションは再帰的にマージ（itemsをマージ）
-          sections.set(item.title, {
-            ...item,
-            items: mergeSubItems(existing.items, item.items)
-          });
-        } else {
-          sections.set(item.title, item);
-        }
-      } else {
-        plainItems.push(item);
-      }
-    } else {
-      // 文字列など
-      plainItems.push(item);
-    }
-  }
-  
-  // 結合順序: 通常要素 → セクション → サブセクション
-  merged.push(...plainItems);
-  merged.push(...Array.from(sections.values()));
-  merged.push(...Array.from(subsections.values()));
-  
-  return merged;
-}
-
-// SectionElementのitemsをマージ
-function mergeSubItems(
-  items1: (string | SubSectionElement)[],
-  items2: (string | SubSectionElement)[]
-): (string | SubSectionElement)[] {
-  const merged: (string | SubSectionElement)[] = [];
-  const subsections: Map<string, SubSectionElement> = new Map();
-  const strings: string[] = [];
-  
-  for (const item of [...items1, ...items2]) {
-    if (typeof item === 'string') {
-      strings.push(item);
-    } else {
-      const existing = subsections.get(item.title);
-      if (existing) {
-        // 同名のサブセクションのitemsを結合
-        subsections.set(item.title, {
-          ...item,
-          items: [...existing.items, ...item.items]
-        });
-      } else {
-        subsections.set(item.title, item);
-      }
-    }
-  }
-  
-  // 順序: 文字列 → サブセクション
-  merged.push(...strings);
-  merged.push(...Array.from(subsections.values()));
-  
-  return merged;
-}
+function merge<T1, T2>(...modules: [PromptModule<T1>, PromptModule<T2>]): PromptModule<T1 | T2>;
 ```
 
-### 2. コンパイル（モジュール + コンテキスト → Elements）
+マージ戦略：
+- 同名セクション内の要素は結合される
+- 同名サブセクションのitemsは結合される
+- createContextは全て実行されて結果がマージされる（後の値で上書き）
+- 順序: 通常要素 → サブセクション
+
+### 2. コンパイル
+
+モジュールとコンテキストから最終的なElement配列を生成：
 
 ```typescript
 interface CompiledPrompt {
@@ -345,121 +243,23 @@ interface CompiledPrompt {
 function compile<TContext>(
   module: PromptModule<TContext>, 
   context: TContext
-): CompiledPrompt {
-  const compiled: CompiledPrompt = {
-    instructions: [],
-    data: [],
-    output: []
-  };
-  
-  // 各セクションをコンパイル
-  for (const [sectionName, sectionContent] of Object.entries(module)) {
-    if (sectionName === 'createContext') continue;
-    if (!sectionContent) continue;
-    
-    const sectionType = getSectionType(sectionName);
-    const compiledElements = compileSection(sectionContent, context);
-    
-    compiled[sectionType].push(...compiledElements);
-  }
-  
-  return compiled;
-}
-
-function compileSection(
-  content: ModuleContent,
-  context: any
-): Element[] {
-  const elements: Element[] = [];
-  
-  for (const item of content) {
-    if (typeof item === 'function') {
-      // DynamicContentを実行
-      const result = item(context);
-      if (result) {
-        if (Array.isArray(result)) {
-          // DynamicElement[]の場合
-          // 注意: SectionElement, SubSectionElementは含まれない
-          elements.push(...result);
-        } else {
-          // 単一のDynamicElement
-          elements.push(result);
-        }
-      }
-    } else if (typeof item === 'string') {
-      // 文字列をTextElementに変換
-      elements.push({
-        type: 'text',
-        content: item
-      } as TextElement);
-    } else if (typeof item === 'object' && 'type' in item) {
-      // すでにElement（静的に定義されたものは全て許可）
-      elements.push(item as Element);
-    }
-  }
-  
-  return elements;
-}
+): CompiledPrompt;
 ```
+
+コンパイル処理：
+1. 標準セクションを自動的にSectionElementに変換
+2. DynamicContentを実行してDynamicElementを生成し、文字列に変換
+3. セクション内の要素を並び替え（通常要素 → サブセクション）
+4. セクションタイプ（instructions/data/output）に応じて分類
 
 ### 3. ドライバーでのフォーマット
 
+各AIモデルに最適な形式への変換：
+
 ```typescript
 interface Driver {
-  // Elementを受け取り、モデル固有の形式に変換
   format(prompt: CompiledPrompt): ModelSpecificFormat;
-  
-  // 各Elementタイプに応じた最適な整形
   formatElement(element: Element): string | ChatMessage;
-}
-```
-
-## ドライバーの責任
-
-ドライバーは各AIモデルに最適な形式への変換を担当します：
-
-### OpenAI Driver の例
-
-```typescript
-class OpenAIDriver implements Driver {
-  formatElement(element: Element): ChatMessage {
-    switch (element.type) {
-      case 'message':
-        return {
-          role: element.role,
-          content: element.content,
-          name: element.name
-        };
-      case 'material':
-        return {
-          role: 'system',
-          content: `# ${element.title}\nID: ${element.id}\n\n${element.content}`
-        };
-      case 'chunk':
-        return {
-          role: 'system',
-          content: `[Part of ${element.partOf}]\n${element.content}`
-        };
-      // ...
-    }
-  }
-}
-```
-
-### Claude Driver の例
-
-```typescript
-class ClaudeDriver implements Driver {
-  formatElement(element: Element): string {
-    switch (element.type) {
-      case 'material':
-        // Claudeに最適化されたXMLタグを使用
-        return `<material id="${element.id}" title="${element.title}">
-${element.content}
-</material>`;
-      // ...
-    }
-  }
 }
 ```
 
@@ -468,46 +268,28 @@ ${element.content}
 ### ストリーミング処理モジュール
 
 ```typescript
-interface StreamingContext {
-  state: ContentWithUsage;
-  chunks: Chunk[];
-  range: { start: number; end: number };
-  iteration: {
-    current: number;
-    total?: number;
-    isFirst: boolean;
-    isLast: boolean;
-  };
-}
-
 const streamProcessingModule: PromptModule<StreamingContext> = {
   createContext: () => ({
     state: { content: '', usage: 0 },
     chunks: [],
-    range: { start: 0, end: 0 },
-    iteration: { current: 0, isFirst: true, isLast: false }
+    range: { start: 0, end: 0 }
   }),
   
   objective: ['ストリーミング処理を実行する'],
   
   processing: [
+    'チャンクごとに順次処理を実行',
     {
-      type: 'section',
-      title: 'Stream Processing',
+      type: 'subsection',
+      content: '',
+      title: 'Algorithm',
       items: [
-        'チャンクごとに順次処理を実行',
-        {
-          type: 'subsection',
-          title: 'Algorithm',
-          items: [
-            '1. 現在の状態を読み込む',
-            '2. チャンクを処理する',
-            '3. 状態を更新する',
-            '4. 次の状態を出力する'
-          ]
-        } as SubSectionElement
+        '現在の状態を読み込む',
+        'チャンクを処理する',
+        '状態を更新する',
+        '次の状態を出力する'
       ]
-    } as SectionElement
+    } as SubSectionElement
   ],
   
   state: [
@@ -533,17 +315,10 @@ const streamProcessingModule: PromptModule<StreamingContext> = {
 ### 対話モジュール
 
 ```typescript
-interface DialogueContext {
-  messages: Message[];
-  materials?: Material[];
-  targetTokens?: number;
-}
-
 const dialogueModule: PromptModule<DialogueContext> = {
   createContext: () => ({
     messages: [],
-    materials: [],
-    targetTokens: 4000
+    materials: []
   }),
   
   objective: ['対話形式で応答を生成する'],
@@ -571,58 +346,27 @@ const dialogueModule: PromptModule<DialogueContext> = {
 };
 ```
 
-## バリデーション
-
-TypeScriptの型システムを基本とし、必要に応じてZodによる実行時検証を追加：
-
-```typescript
-import { z } from 'zod';
-
-const ElementSchema = z.discriminatedUnion('type', [
-  z.object({
-    type: z.literal('message'),
-    content: z.union([z.string(), AttachmentSchema.array()]),
-    role: z.enum(['system', 'assistant', 'user']),
-    name: z.string().optional()
-  }),
-  // ... 他のElement型
-]);
-
-function validateModule(module: unknown): PromptModule {
-  return PromptModuleSchema.parse(module);
-}
-```
-
-## パッケージ構成
-
-```
-@moduler-prompt/
-├── core/          # 基本型定義、merge、compile
-├── driver/        # 各AIモデル向けドライバー
-│   ├── openai/
-│   ├── anthropic/
-│   └── vertex/
-├── process/       # ストリーミング等の処理パターン
-└── presets/       # 事前定義モジュール集
-```
-
 ## 重要な制約
 
 ### 動的コンテンツの制限
-- **DynamicContent（関数）はSectionElement, SubSectionElementを生成できない**
+- DynamicContentはSectionElement, SubSectionElementを生成できない
 - 生成可能: TextElement, MessageElement, MaterialElement, ChunkElement
-- 理由: マージ時の順序制御（サブセクションを最後に配置）を保証するため
+- 理由: セクション構造は静的に定義されるべき
 
 ### 階層構造の制限
-- **最大2階層まで**: SectionElement → SubSectionElement → string
+- 最大2階層: Section → SubSection → string
 - SubSectionElementのitemsは文字列のみ
 - 深い階層化は避ける設計
 
+### 標準セクションの自動処理
+- 標準セクションの内容は自動的にSectionElementとして処理
+- 明示的なSectionElement指定は不要（冗長）
+- titleは標準セクション定義から自動設定
+
 ## まとめ
 
-- **フレームワークが概念を定義**: セクション名を制限して一貫性を確保
-- **Elementによる型安全性**: 各要素タイプに応じた構造を定義
-- **ドライバーでの最適化**: モデル固有のフォーマットはドライバーが担当
-- **静的な定義**: エラー時は失敗、フォールバックは不要
-- **段階的な処理**: merge → compile → format の明確な分離
-- **動的と静的の明確な分離**: 構造は静的に定義、データのみ動的に生成
+- **シンプルな記法**: 標準セクションは配列で簡潔に記述
+- **自動変換**: コンパイル時に適切な構造に自動変換
+- **型安全性**: TypeScriptの型システムで保証
+- **明確な分離**: 構造は静的、データは動的
+- **段階的処理**: merge → compile → format

--- a/packages/core/eslint.config.js
+++ b/packages/core/eslint.config.js
@@ -1,0 +1,34 @@
+import js from '@eslint/js';
+import typescript from '@typescript-eslint/eslint-plugin';
+import typescriptParser from '@typescript-eslint/parser';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      parser: typescriptParser,
+      parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module'
+      }
+    },
+    plugins: {
+      '@typescript-eslint': typescript
+    },
+    rules: {
+      ...typescript.configs.recommended.rules,
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      '@typescript-eslint/consistent-type-imports': 'error',
+      'no-console': 'warn',
+      'no-debugger': 'error',
+      'no-case-declarations': 'off',
+      'no-redeclare': 'off'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**', '*.config.js', '*.config.ts']
+  }
+];

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,20 +22,23 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "test": "jest",
+    "test": "vitest",
+    "test:ui": "vitest --ui",
+    "test:run": "vitest run",
     "clean": "rm -rf dist",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {},
   "devDependencies": {
-    "@types/jest": "^29.0.0",
+    "@eslint/js": "^9.34.0",
     "@types/node": "^20.0.0",
-    "jest": "^29.0.0",
-    "ts-jest": "^29.0.0",
-    "typescript": "^5.0.0"
+    "@typescript-eslint/eslint-plugin": "^8.42.0",
+    "@typescript-eslint/parser": "^8.42.0",
+    "@vitest/ui": "^3.2.4",
+    "eslint": "^9.34.0",
+    "typescript": "^5.0.0",
+    "vitest": "^3.2.4"
   },
-  "peerDependencies": {},
   "engines": {
     "node": ">=18.0.0"
   },

--- a/packages/core/src/compile.test.ts
+++ b/packages/core/src/compile.test.ts
@@ -1,419 +1,329 @@
-/**
- * Tests for compile functionality
- */
-
-import { compile, createContext } from '../compile';
-import type {
-  PromptModule,
-  SectionElement,
+import { describe, it, expect } from 'vitest';
+import { compile, createContext } from './compile';
+import type { 
+  PromptModule, 
   SubSectionElement,
   TextElement,
   MessageElement,
   MaterialElement,
-  ChunkElement,
-  DynamicContent,
-  DynamicElement
-} from '../types';
+  ChunkElement
+} from './types';
 
 describe('compile', () => {
-  describe('basic compilation', () => {
-    it('should compile strings to TextElements', () => {
-      const module: PromptModule = {
-        objective: ['Be helpful', 'Be accurate'],
-        instructions: ['Step 1', 'Step 2']
-      };
+  describe('基本的なコンパイル', () => {
+    it('空のモジュールをコンパイルできる', () => {
+      const module: PromptModule = {};
+      const context = {};
+      const result = compile(module, context);
       
-      const compiled = compile(module, {});
-      
-      // Check instructions section
-      const objectiveHeader = compiled.instructions[0] as TextElement;
-      expect(objectiveHeader.type).toBe('text');
-      expect(objectiveHeader.content).toContain('Objective and Role');
-      
-      const objective1 = compiled.instructions[1] as TextElement;
-      expect(objective1.type).toBe('text');
-      expect(objective1.content).toBe('Be helpful');
-      
-      const objective2 = compiled.instructions[2] as TextElement;
-      expect(objective2.type).toBe('text');
-      expect(objective2.content).toBe('Be accurate');
-    });
-    
-    it('should preserve existing Elements', () => {
-      const message: MessageElement = {
-        type: 'message',
-        content: 'Hello',
-        role: 'user',
-        name: 'John'
-      };
-      
-      const module: PromptModule = {
-        messages: [message]
-      };
-      
-      const compiled = compile(module, {});
-      
-      const compiledMessage = compiled.data[1] as MessageElement;
-      expect(compiledMessage).toEqual(message);
-    });
-    
-    it('should organize elements by section type', () => {
-      const module: PromptModule = {
-        // Instructions type
-        objective: ['Objective'],
-        guidelines: ['Guideline'],
-        
-        // Data type
-        state: ['State'],
-        materials: ['Material'],
-        
-        // Output type
-        cue: ['Output cue'],
-        schema: ['Schema']
-      };
-      
-      const compiled = compile(module, {});
-      
-      // Check that sections are properly categorized
-      expect(compiled.instructions.some(e => 
-        e.type === 'text' && e.content.includes('Objective and Role')
-      )).toBe(true);
-      expect(compiled.instructions.some(e => 
-        e.type === 'text' && e.content.includes('Guidelines')
-      )).toBe(true);
-      
-      expect(compiled.data.some(e => 
-        e.type === 'text' && e.content.includes('Current State')
-      )).toBe(true);
-      expect(compiled.data.some(e => 
-        e.type === 'text' && e.content.includes('Prepared Materials')
-      )).toBe(true);
-      
-      expect(compiled.output.some(e => 
-        e.type === 'text' && e.content.includes('Output')
-      )).toBe(true);
-      expect(compiled.output.some(e => 
-        e.type === 'text' && e.content.includes('Output Schema')
-      )).toBe(true);
-    });
-  });
-  
-  describe('dynamic content execution', () => {
-    it('should execute dynamic content with context', () => {
-      interface TestContext {
-        value: string;
-      }
-      
-      const dynamic: DynamicContent<TestContext> = (context) => ({
-        type: 'text',
-        content: `Value: ${context.value}`
+      expect(result).toEqual({
+        instructions: [],
+        data: [],
+        output: []
       });
-      
-      const module: PromptModule<TestContext> = {
-        state: [dynamic]
-      };
-      
-      const context: TestContext = { value: 'test' };
-      const compiled = compile(module, context);
-      
-      const dynamicResult = compiled.data[1] as TextElement;
-      expect(dynamicResult.type).toBe('text');
-      expect(dynamicResult.content).toBe('Value: test');
     });
-    
-    it('should handle dynamic content returning arrays', () => {
-      interface TestContext {
-        items: string[];
-      }
-      
-      const dynamic: DynamicContent<TestContext> = (context) => 
-        context.items.map(item => ({
-          type: 'text',
-          content: item
-        } as TextElement));
-      
-      const module: PromptModule<TestContext> = {
-        chunks: [dynamic]
-      };
-      
-      const context: TestContext = { items: ['Item 1', 'Item 2'] };
-      const compiled = compile(module, context);
-      
-      const item1 = compiled.data[1] as TextElement;
-      const item2 = compiled.data[2] as TextElement;
-      
-      expect(item1.content).toBe('Item 1');
-      expect(item2.content).toBe('Item 2');
-    });
-    
-    it('should handle dynamic content returning null', () => {
-      const dynamic: DynamicContent = () => null;
-      
+
+    it('標準セクションがSectionElementに変換される', () => {
       const module: PromptModule = {
-        state: ['Before', dynamic, 'After']
+        objective: ['AIアシスタントとして動作する'],
+        processing: ['データを分析', '結果を生成']
       };
+      const context = {};
+      const result = compile(module, context);
       
-      const compiled = compile(module, {});
-      
-      // null result should be ignored
-      const before = compiled.data[1] as TextElement;
-      const after = compiled.data[2] as TextElement;
-      
-      expect(before.content).toBe('Before');
-      expect(after.content).toBe('After');
-      expect(compiled.data.length).toBe(3); // Header + 2 items
-    });
-    
-    it('should not allow dynamic content to create SectionElement', () => {
-      // This test verifies the type system constraint
-      // Dynamic content cannot return SectionElement or SubSectionElement
-      
-      const dynamic: DynamicContent = () => ({
-        type: 'text',
-        content: 'Valid dynamic element'
-      });
-      
-      // The following would be a TypeScript error:
-      // const invalid: DynamicContent = () => ({
-      //   type: 'section',
-      //   content: '',
-      //   title: 'Invalid',
-      //   items: []
-      // } as SectionElement);
-      
-      const module: PromptModule = {
-        instructions: [dynamic]
-      };
-      
-      const compiled = compile(module, {});
-      
-      const result = compiled.instructions[1] as TextElement;
-      expect(result.type).toBe('text');
-    });
-  });
-  
-  describe('section and subsection handling', () => {
-    it('should compile static SectionElements', () => {
-      const section: SectionElement = {
+      expect(result.instructions).toHaveLength(2);
+      expect(result.instructions[0]).toEqual({
         type: 'section',
         content: '',
-        title: 'Algorithm',
-        items: ['Step 1', 'Step 2']
-      };
-      
-      const module: PromptModule = {
-        processing: [section]
-      };
-      
-      const compiled = compile(module, {});
-      
-      // Should have header + section
-      const sectionElement = compiled.instructions[1] as SectionElement;
-      expect(sectionElement.type).toBe('section');
-      expect(sectionElement.title).toBe('Algorithm');
-      expect(sectionElement.items).toEqual(['Step 1', 'Step 2']);
-    });
-    
-    it('should compile nested SubSectionElements', () => {
-      const subsection: SubSectionElement = {
-        type: 'subsection',
-        content: '',
-        title: 'Details',
-        items: ['Detail 1', 'Detail 2']
-      };
-      
-      const section: SectionElement = {
+        title: 'Objective and Role',
+        items: ['AIアシスタントとして動作する']
+      });
+      expect(result.instructions[1]).toEqual({
         type: 'section',
         content: '',
-        title: 'Main',
-        items: ['Intro', subsection]
-      };
-      
+        title: 'Processing Algorithm',
+        items: ['データを分析', '結果を生成']
+      });
+    });
+
+    it('SubSectionElementを含むセクションを処理できる', () => {
       const module: PromptModule = {
-        instructions: [section]
+        processing: [
+          '入力を検証',
+          {
+            type: 'subsection',
+            content: '',
+            title: '変換処理',
+            items: ['正規化', '特徴抽出']
+          } as SubSectionElement,
+          '出力を生成'
+        ]
       };
+      const context = {};
+      const result = compile(module, context);
       
-      const compiled = compile(module, {});
-      
-      const compiledSection = compiled.instructions[1] as SectionElement;
-      expect(compiledSection.items[0]).toBe('Intro');
-      
-      const compiledSubsection = compiledSection.items[1] as SubSectionElement;
-      expect(compiledSubsection.type).toBe('subsection');
-      expect(compiledSubsection.items).toEqual(['Detail 1', 'Detail 2']);
+      expect(result.instructions).toHaveLength(1);
+      expect(result.instructions[0]).toEqual({
+        type: 'section',
+        content: '',
+        title: 'Processing Algorithm',
+        items: [
+          '入力を検証',
+          '出力を生成',
+          {
+            type: 'subsection',
+            content: '',
+            title: '変換処理',
+            items: ['正規化', '特徴抽出']
+          }
+        ]
+      });
     });
   });
-  
-  describe('createContext helper', () => {
-    it('should call createContext if provided', () => {
-      interface TestContext {
-        initialized: boolean;
-      }
-      
-      const module: PromptModule<TestContext> = {
-        createContext: () => ({ initialized: true })
-      };
-      
-      const context = createContext(module);
-      
-      expect(context.initialized).toBe(true);
-    });
-    
-    it('should return empty object if createContext not provided', () => {
-      const module: PromptModule = {
-        objective: ['Test']
-      };
-      
-      const context = createContext(module);
-      
-      expect(context).toEqual({});
-    });
-  });
-  
-  describe('real-world scenarios', () => {
-    it('should compile a streaming processing module', () => {
-      interface StreamingContext {
-        state: { content: string; usage: number };
-        chunks: Array<{ content: string; partOf: string; usage: number }>;
-        range: { start: number; end: number };
-      }
-      
-      const module: PromptModule<StreamingContext> = {
-        createContext: () => ({
-          state: { content: '', usage: 0 },
-          chunks: [],
-          range: { start: 0, end: 0 }
-        }),
-        
-        objective: ['Process chunks in streaming fashion'],
-        
-        processing: [{
-          type: 'section',
-          content: '',
-          title: 'Algorithm',
-          items: [
-            'Read current state',
-            {
-              type: 'subsection',
-              content: '',
-              title: 'Processing Steps',
-              items: ['Process chunk', 'Update state', 'Output result']
-            } as SubSectionElement
-          ]
-        } as SectionElement],
-        
+
+  describe('DynamicContentの処理', () => {
+    it('TextElementを生成するDynamicContent', () => {
+      const module: PromptModule<{ value: string }> = {
         state: [
-          (context: StreamingContext) => ({
+          (context) => ({
             type: 'text',
-            content: `Current state: ${context.state.content}`
+            content: `Value: ${context.value}`
           } as TextElement)
-        ],
-        
-        chunks: [
-          (context: StreamingContext) => 
-            context.chunks.slice(context.range.start, context.range.end)
-              .map(chunk => ({
-                type: 'chunk',
-                content: chunk.content,
-                partOf: chunk.partOf,
-                usage: chunk.usage
-              } as ChunkElement))
         ]
+      };
+      const context = { value: 'test123' };
+      const result = compile(module, context);
+      
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toEqual({
+        type: 'section',
+        content: '',
+        title: 'Current State',
+        items: ['Value: test123']
+      });
+    });
+
+    it('MessageElementを生成するDynamicContent', () => {
+      const module: PromptModule<{ message: string }> = {
+        messages: [
+          (context) => ({
+            type: 'message',
+            content: context.message,
+            role: 'user'
+          } as MessageElement)
+        ]
+      };
+      const context = { message: 'Hello, AI!' };
+      const result = compile(module, context);
+      
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toEqual({
+        type: 'section',
+        content: '',
+        title: 'Messages',
+        items: ['[User]: Hello, AI!']
+      });
+    });
+
+    it('MaterialElementを生成するDynamicContent', () => {
+      const module: PromptModule<{ doc: { id: string; title: string; content: string } }> = {
+        materials: [
+          (context) => ({
+            type: 'material',
+            content: context.doc.content,
+            id: context.doc.id,
+            title: context.doc.title
+          } as MaterialElement)
+        ]
+      };
+      const context = { 
+        doc: { 
+          id: 'doc1', 
+          title: 'API Guide', 
+          content: 'API documentation content' 
+        } 
+      };
+      const result = compile(module, context);
+      
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toEqual({
+        type: 'section',
+        content: '',
+        title: 'Prepared Materials',
+        items: ['[Material: API Guide]\nAPI documentation content']
+      });
+    });
+
+    it('ChunkElementを生成するDynamicContent', () => {
+      const module: PromptModule<{ chunks: Array<{ content: string; partOf: string }> }> = {
+        chunks: [
+          (context) => context.chunks.map(chunk => ({
+            type: 'chunk',
+            content: chunk.content,
+            partOf: chunk.partOf
+          } as ChunkElement))
+        ]
+      };
+      const context = {
+        chunks: [
+          { content: 'Part 1 content', partOf: 'document.txt' },
+          { content: 'Part 2 content', partOf: 'document.txt' }
+        ]
+      };
+      const result = compile(module, context);
+      
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toEqual({
+        type: 'section',
+        content: '',
+        title: 'Input Chunks',
+        items: [
+          '[Chunk from document.txt]\nPart 1 content',
+          '[Chunk from document.txt]\nPart 2 content'
+        ]
+      });
+    });
+
+    it('nullを返すDynamicContentは無視される', () => {
+      const module: PromptModule<{ includeState: boolean }> = {
+        state: [
+          '固定の状態',
+          (context) => context.includeState 
+            ? { type: 'text', content: '動的な状態' } as TextElement
+            : null
+        ]
+      };
+      
+      const result1 = compile(module, { includeState: true });
+      expect(result1.data[0]).toEqual({
+        type: 'section',
+        content: '',
+        title: 'Current State',
+        items: ['固定の状態', '動的な状態']
+      });
+      
+      const result2 = compile(module, { includeState: false });
+      expect(result2.data[0]).toEqual({
+        type: 'section',
+        content: '',
+        title: 'Current State',
+        items: ['固定の状態']
+      });
+    });
+  });
+
+  describe('セクションタイプの分類', () => {
+    it('Instructions, Data, Outputセクションが正しく分類される', () => {
+      const module: PromptModule = {
+        // Instructions
+        objective: ['目的'],
+        instructions: ['指示'],
+        
+        // Data
+        state: ['状態'],
+        messages: ['メッセージ'],
+        
+        // Output
+        cue: ['出力'],
+        schema: ['スキーマ']
+      };
+      const context = {};
+      const result = compile(module, context);
+      
+      expect(result.instructions).toHaveLength(2);
+      expect(result.instructions.map(e => e.title)).toEqual([
+        'Objective and Role',
+        'Instructions'
+      ]);
+      
+      expect(result.data).toHaveLength(2);
+      expect(result.data.map(e => e.title)).toEqual([
+        'Current State',
+        'Messages'
+      ]);
+      
+      expect(result.output).toHaveLength(2);
+      expect(result.output.map(e => e.title)).toEqual([
+        'Output',
+        'Output Schema'
+      ]);
+    });
+  });
+
+  describe('複雑なケース', () => {
+    it('文字列、SubSectionElement、DynamicContentを混在させる', () => {
+      interface Context {
+        currentStep: number;
+        totalSteps: number;
+        details: string[];
+      }
+      
+      const module: PromptModule<Context> = {
+        processing: [
+          '処理を開始',
+          (context) => ({
+            type: 'text',
+            content: `ステップ ${context.currentStep}/${context.totalSteps} を実行中`
+          } as TextElement),
+          {
+            type: 'subsection',
+            content: '',
+            title: '詳細手順',
+            items: ['初期化', '検証', '実行']
+          } as SubSectionElement,
+          (context) => context.details.map(detail => ({
+            type: 'text',
+            content: detail
+          } as TextElement)),
+          '処理を完了'
+        ]
+      };
+      
+      const context: Context = {
+        currentStep: 3,
+        totalSteps: 5,
+        details: ['詳細1', '詳細2']
+      };
+      
+      const result = compile(module, context);
+      
+      expect(result.instructions).toHaveLength(1);
+      expect(result.instructions[0]).toEqual({
+        type: 'section',
+        content: '',
+        title: 'Processing Algorithm',
+        items: [
+          '処理を開始',
+          'ステップ 3/5 を実行中',
+          '詳細1',
+          '詳細2',
+          '処理を完了',
+          {
+            type: 'subsection',
+            content: '',
+            title: '詳細手順',
+            items: ['初期化', '検証', '実行']
+          }
+        ]
+      });
+    });
+  });
+
+  describe('createContext', () => {
+    it('createContextがある場合はそれを使用', () => {
+      const module: PromptModule<{ value: number }> = {
+        createContext: () => ({ value: 42 })
       };
       
       const context = createContext(module);
-      context.chunks = [
-        { content: 'Chunk 1', partOf: 'file.txt', usage: 10 },
-        { content: 'Chunk 2', partOf: 'file.txt', usage: 15 }
-      ];
-      context.range = { start: 0, end: 2 };
-      context.state.content = 'Previous state';
-      
-      const compiled = compile(module, context);
-      
-      // Check objective
-      const objective = compiled.instructions.find(e => 
-        e.type === 'text' && e.content === 'Process chunks in streaming fashion'
-      );
-      expect(objective).toBeDefined();
-      
-      // Check processing section
-      const processingSection = compiled.instructions.find(e => 
-        e.type === 'section'
-      ) as SectionElement;
-      expect(processingSection).toBeDefined();
-      expect(processingSection.title).toBe('Algorithm');
-      
-      // Check state
-      const stateText = compiled.data.find(e => 
-        e.type === 'text' && e.content.includes('Previous state')
-      );
-      expect(stateText).toBeDefined();
-      
-      // Check chunks
-      const chunks = compiled.data.filter(e => e.type === 'chunk');
-      expect(chunks.length).toBe(2);
-      expect((chunks[0] as ChunkElement).partOf).toBe('file.txt');
+      expect(context).toEqual({ value: 42 });
     });
-    
-    it('should compile a dialogue module', () => {
-      interface DialogueContext {
-        messages: Array<{ content: string; role: 'user' | 'assistant'; name?: string }>;
-        materials?: Array<{ id: string; title: string; content: string; usage: number }>;
-      }
+
+    it('createContextがない場合は空オブジェクトを返す', () => {
+      const module: PromptModule = {};
       
-      const module: PromptModule<DialogueContext> = {
-        createContext: () => ({
-          messages: [],
-          materials: []
-        }),
-        
-        objective: ['Engage in helpful dialogue'],
-        
-        messages: [
-          (context: DialogueContext) =>
-            context.messages.map(msg => ({
-              type: 'message',
-              content: msg.content,
-              role: msg.role,
-              name: msg.name
-            } as MessageElement))
-        ],
-        
-        materials: [
-          (context: DialogueContext) =>
-            context.materials?.map(mat => ({
-              type: 'material',
-              content: mat.content,
-              id: mat.id,
-              title: mat.title,
-              usage: mat.usage
-            } as MaterialElement)) || []
-        ]
-      };
-      
-      const context: DialogueContext = {
-        messages: [
-          { content: 'Hello', role: 'user', name: 'Alice' },
-          { content: 'Hi there!', role: 'assistant' }
-        ],
-        materials: [
-          { id: 'doc1', title: 'Guide', content: 'Guidelines', usage: 50 }
-        ]
-      };
-      
-      const compiled = compile(module, context);
-      
-      // Check messages
-      const messages = compiled.data.filter(e => e.type === 'message');
-      expect(messages.length).toBe(2);
-      expect((messages[0] as MessageElement).role).toBe('user');
-      expect((messages[0] as MessageElement).name).toBe('Alice');
-      
-      // Check materials
-      const materials = compiled.data.filter(e => e.type === 'material');
-      expect(materials.length).toBe(1);
-      expect((materials[0] as MaterialElement).title).toBe('Guide');
+      const context = createContext(module);
+      expect(context).toEqual({});
     });
   });
 });

--- a/packages/core/src/merge.test.ts
+++ b/packages/core/src/merge.test.ts
@@ -1,317 +1,424 @@
-/**
- * Tests for merge functionality
- */
-
-import { merge } from '../merge';
-import type {
-  PromptModule,
-  SectionElement,
-  SubSectionElement,
-  TextElement,
-  MessageElement,
-  DynamicContent
-} from '../types';
+import { describe, it, expect } from 'vitest';
+import { merge } from './merge';
+import type { PromptModule, SubSectionElement } from './types';
 
 describe('merge', () => {
-  describe('basic merging', () => {
-    it('should merge two simple modules', () => {
-      const module1: PromptModule = {
-        objective: ['Task 1'],
-        instructions: ['Step 1']
-      };
-      
-      const module2: PromptModule = {
-        objective: ['Task 2'],
-        guidelines: ['Guide 1']
-      };
-      
-      const merged = merge(module1, module2);
-      
-      expect(merged.objective).toEqual(['Task 1', 'Task 2']);
-      expect(merged.instructions).toEqual(['Step 1']);
-      expect(merged.guidelines).toEqual(['Guide 1']);
-    });
-    
-    it('should handle empty modules', () => {
+  describe('基本的なマージ', () => {
+    it('空のモジュールをマージできる', () => {
       const module1: PromptModule = {};
-      const module2: PromptModule = {
-        objective: ['Task']
-      };
+      const module2: PromptModule = {};
+      const result = merge(module1, module2);
       
-      const merged = merge(module1, module2);
-      
-      expect(merged.objective).toEqual(['Task']);
+      expect(result).toEqual({});
     });
-    
-    it('should merge multiple modules', () => {
-      const module1: PromptModule = { objective: ['Task 1'] };
-      const module2: PromptModule = { objective: ['Task 2'] };
-      const module3: PromptModule = { objective: ['Task 3'] };
-      
-      const merged = merge(module1, module2, module3);
-      
-      expect(merged.objective).toEqual(['Task 1', 'Task 2', 'Task 3']);
-    });
-  });
-  
-  describe('createContext handling', () => {
-    it('should use the first createContext found', () => {
-      const context1 = { value: 1 };
-      const context2 = { value: 2 };
-      
-      const module1: PromptModule<typeof context1> = {
-        createContext: () => context1
-      };
-      
-      const module2: PromptModule<typeof context2> = {
-        createContext: () => context2
-      };
-      
-      const merged = merge(module1, module2);
-      
-      expect(merged.createContext?.()).toBe(context1);
-    });
-  });
-  
-  describe('subsection merging', () => {
-    it('should merge subsections with same title', () => {
-      const subsection1: SubSectionElement = {
-        type: 'subsection',
-        content: '',
-        title: 'Algorithm',
-        items: ['Step 1', 'Step 2']
-      };
-      
-      const subsection2: SubSectionElement = {
-        type: 'subsection',
-        content: '',
-        title: 'Algorithm',
-        items: ['Step 3']
-      };
-      
+
+    it('片方が空の場合はもう片方の内容が維持される', () => {
       const module1: PromptModule = {
-        instructions: [subsection1]
+        objective: ['目的1']
       };
+      const module2: PromptModule = {};
+      const result = merge(module1, module2);
       
-      const module2: PromptModule = {
-        instructions: [subsection2]
-      };
-      
-      const merged = merge(module1, module2);
-      const mergedSubsection = merged.instructions?.[0] as SubSectionElement;
-      
-      expect(mergedSubsection.type).toBe('subsection');
-      expect(mergedSubsection.title).toBe('Algorithm');
-      expect(mergedSubsection.items).toEqual(['Step 1', 'Step 2', 'Step 3']);
+      expect(result.objective).toEqual(['目的1']);
     });
-    
-    it('should place subsections after plain items', () => {
-      const subsection: SubSectionElement = {
-        type: 'subsection',
-        content: '',
-        title: 'Details',
-        items: ['Detail 1']
-      };
-      
+
+    it('同じセクションの文字列が結合される', () => {
       const module1: PromptModule = {
-        instructions: [subsection, 'Plain text']
+        objective: ['目的1'],
+        processing: ['処理1']
       };
-      
       const module2: PromptModule = {
-        instructions: ['Another text']
+        objective: ['目的2'],
+        processing: ['処理2']
       };
+      const result = merge(module1, module2);
       
-      const merged = merge(module1, module2);
-      
-      // Order should be: plain texts first, then subsections
-      expect(merged.instructions?.[0]).toBe('Plain text');
-      expect(merged.instructions?.[1]).toBe('Another text');
-      expect((merged.instructions?.[2] as SubSectionElement).type).toBe('subsection');
+      expect(result.objective).toEqual(['目的1', '目的2']);
+      expect(result.processing).toEqual(['処理1', '処理2']);
     });
   });
-  
-  describe('section merging', () => {
-    it('should merge sections with same title', () => {
-      const section1: SectionElement = {
-        type: 'section',
-        content: '',
-        title: 'Processing',
-        items: ['Process 1', 'Process 2']
-      };
-      
-      const section2: SectionElement = {
-        type: 'section',
-        content: '',
-        title: 'Processing',
-        items: ['Process 3']
-      };
-      
+
+  describe('SubSectionElementのマージ', () => {
+    it('異なるサブセクションは両方保持される', () => {
       const module1: PromptModule = {
-        processing: [section1]
-      };
-      
-      const module2: PromptModule = {
-        processing: [section2]
-      };
-      
-      const merged = merge(module1, module2);
-      const mergedSection = merged.processing?.[0] as SectionElement;
-      
-      expect(mergedSection.type).toBe('section');
-      expect(mergedSection.title).toBe('Processing');
-      expect(mergedSection.items).toEqual(['Process 1', 'Process 2', 'Process 3']);
-    });
-    
-    it('should merge nested subsections within sections', () => {
-      const subsection1: SubSectionElement = {
-        type: 'subsection',
-        content: '',
-        title: 'SubAlgo',
-        items: ['Sub 1']
-      };
-      
-      const subsection2: SubSectionElement = {
-        type: 'subsection',
-        content: '',
-        title: 'SubAlgo',
-        items: ['Sub 2']
-      };
-      
-      const section1: SectionElement = {
-        type: 'section',
-        content: '',
-        title: 'MainProcess',
-        items: ['Intro', subsection1]
-      };
-      
-      const section2: SectionElement = {
-        type: 'section',
-        content: '',
-        title: 'MainProcess',
-        items: [subsection2, 'Outro']
-      };
-      
-      const module1: PromptModule = {
-        processing: [section1]
-      };
-      
-      const module2: PromptModule = {
-        processing: [section2]
-      };
-      
-      const merged = merge(module1, module2);
-      const mergedSection = merged.processing?.[0] as SectionElement;
-      
-      expect(mergedSection.items[0]).toBe('Intro');
-      expect(mergedSection.items[1]).toBe('Outro');
-      
-      const mergedSubsection = mergedSection.items[2] as SubSectionElement;
-      expect(mergedSubsection.type).toBe('subsection');
-      expect(mergedSubsection.title).toBe('SubAlgo');
-      expect(mergedSubsection.items).toEqual(['Sub 1', 'Sub 2']);
-    });
-  });
-  
-  describe('element ordering', () => {
-    it('should maintain order: plain items → sections → subsections', () => {
-      const text: TextElement = {
-        type: 'text',
-        content: 'Plain text element'
-      };
-      
-      const section: SectionElement = {
-        type: 'section',
-        content: '',
-        title: 'Section',
-        items: ['Item']
-      };
-      
-      const subsection: SubSectionElement = {
-        type: 'subsection',
-        content: '',
-        title: 'Subsection',
-        items: ['Item']
-      };
-      
-      const module: PromptModule = {
-        instructions: [subsection, 'String', section, text]
-      };
-      
-      const merged = merge(module);
-      
-      expect(merged.instructions?.[0]).toBe('String');
-      expect((merged.instructions?.[1] as TextElement).type).toBe('text');
-      expect((merged.instructions?.[2] as SectionElement).type).toBe('section');
-      expect((merged.instructions?.[3] as SubSectionElement).type).toBe('subsection');
-    });
-  });
-  
-  describe('dynamic content handling', () => {
-    it('should preserve dynamic content functions', () => {
-      const dynamicContent: DynamicContent = (context) => ({
-        type: 'text',
-        content: 'Dynamic'
-      });
-      
-      const module1: PromptModule = {
-        state: [dynamicContent]
-      };
-      
-      const module2: PromptModule = {
-        state: ['Static']
-      };
-      
-      const merged = merge(module1, module2);
-      
-      expect(typeof merged.state?.[0]).toBe('function');
-      expect(merged.state?.[1]).toBe('Static');
-    });
-  });
-  
-  describe('complex scenarios', () => {
-    it('should handle mixed content types correctly', () => {
-      const message: MessageElement = {
-        type: 'message',
-        content: 'Hello',
-        role: 'user'
-      };
-      
-      const section: SectionElement = {
-        type: 'section',
-        content: '',
-        title: 'Complex',
-        items: ['Item 1']
-      };
-      
-      const subsection: SubSectionElement = {
-        type: 'subsection',
-        content: '',
-        title: 'Sub',
-        items: ['Sub 1']
-      };
-      
-      const dynamic: DynamicContent = () => null;
-      
-      const module: PromptModule = {
-        messages: [
-          'String 1',
-          subsection,
-          message,
-          section,
-          dynamic,
-          'String 2'
+        processing: [
+          '処理1',
+          {
+            type: 'subsection',
+            content: '',
+            title: 'サブ1',
+            items: ['項目1']
+          } as SubSectionElement
         ]
       };
+      const module2: PromptModule = {
+        processing: [
+          '処理2',
+          {
+            type: 'subsection',
+            content: '',
+            title: 'サブ2',
+            items: ['項目2']
+          } as SubSectionElement
+        ]
+      };
+      const result = merge(module1, module2);
       
-      const merged = merge(module);
+      expect(result.processing).toEqual([
+        '処理1',
+        '処理2',
+        {
+          type: 'subsection',
+          content: '',
+          title: 'サブ1',
+          items: ['項目1']
+        },
+        {
+          type: 'subsection',
+          content: '',
+          title: 'サブ2',
+          items: ['項目2']
+        }
+      ]);
+    });
+
+    it('同名のサブセクションはitemsがマージされる', () => {
+      const module1: PromptModule = {
+        processing: [
+          {
+            type: 'subsection',
+            content: '',
+            title: '共通サブセクション',
+            items: ['項目1', '項目2']
+          } as SubSectionElement
+        ]
+      };
+      const module2: PromptModule = {
+        processing: [
+          {
+            type: 'subsection',
+            content: '',
+            title: '共通サブセクション',
+            items: ['項目3', '項目4']
+          } as SubSectionElement
+        ]
+      };
+      const result = merge(module1, module2);
       
-      // Check order
-      expect(merged.messages?.[0]).toBe('String 1');
-      expect(merged.messages?.[1]).toBe('String 2');
-      expect((merged.messages?.[2] as MessageElement).type).toBe('message');
-      expect(typeof merged.messages?.[3]).toBe('function');
-      expect((merged.messages?.[4] as SectionElement).type).toBe('section');
-      expect((merged.messages?.[5] as SubSectionElement).type).toBe('subsection');
+      expect(result.processing).toEqual([
+        {
+          type: 'subsection',
+          content: '',
+          title: '共通サブセクション',
+          items: ['項目1', '項目2', '項目3', '項目4']
+        }
+      ]);
+    });
+  });
+
+  describe('DynamicContentのマージ', () => {
+    it('DynamicContentはそのまま保持される', () => {
+      const dynamic1 = (_context: any) => ({ type: 'text', content: 'Dynamic1' });
+      const dynamic2 = (_context: any) => ({ type: 'text', content: 'Dynamic2' });
+      
+      const module1: PromptModule = {
+        state: [dynamic1]
+      };
+      const module2: PromptModule = {
+        state: [dynamic2]
+      };
+      const result = merge(module1, module2);
+      
+      expect(result.state).toHaveLength(2);
+      expect(result.state![0]).toBe(dynamic1);
+      expect(result.state![1]).toBe(dynamic2);
+    });
+
+    it('文字列、SubSectionElement、DynamicContentが混在してもマージできる', () => {
+      const dynamic = (_context: any) => ({ type: 'text', content: 'Dynamic' });
+      
+      const module1: PromptModule = {
+        processing: [
+          '文字列1',
+          dynamic,
+          {
+            type: 'subsection',
+            content: '',
+            title: 'サブ1',
+            items: ['項目1']
+          } as SubSectionElement
+        ]
+      };
+      const module2: PromptModule = {
+        processing: [
+          '文字列2',
+          {
+            type: 'subsection',
+            content: '',
+            title: 'サブ2',
+            items: ['項目2']
+          } as SubSectionElement
+        ]
+      };
+      const result = merge(module1, module2);
+      
+      expect(result.processing).toHaveLength(5);
+      expect(result.processing![0]).toBe('文字列1');
+      expect(result.processing![1]).toBe(dynamic);
+      expect(result.processing![2]).toBe('文字列2');
+      expect((result.processing![3] as SubSectionElement).title).toBe('サブ1');
+      expect((result.processing![4] as SubSectionElement).title).toBe('サブ2');
+    });
+  });
+
+  describe('createContextのマージ', () => {
+    it('両方のcreateContextが実行されて結果がマージされる', () => {
+      const module1: PromptModule<{ a: number }> = {
+        createContext: () => ({ a: 1 })
+      };
+      const module2: PromptModule<{ b: number }> = {
+        createContext: () => ({ b: 2 })
+      };
+      const result = merge(module1, module2);
+      
+      expect(result.createContext!()).toEqual({ a: 1, b: 2 });
+    });
+
+    it('同じプロパティは後のモジュールの値で上書きされる', () => {
+      const module1: PromptModule<{ value: number; a: string }> = {
+        createContext: () => ({ value: 1, a: 'first' })
+      };
+      const module2: PromptModule<{ value: number; b: string }> = {
+        createContext: () => ({ value: 2, b: 'second' })
+      };
+      const result = merge(module1, module2);
+      
+      expect(result.createContext!()).toEqual({ value: 2, a: 'first', b: 'second' });
+    });
+
+    it('片方のモジュールにcreateContextがない場合は存在する方の結果が使用される', () => {
+      const module1: PromptModule = {};
+      const module2: PromptModule<{ value: string }> = {
+        createContext: () => ({ value: 'test' })
+      };
+      const result = merge(module1, module2);
+      
+      expect(result.createContext!()).toEqual({ value: 'test' });
+    });
+
+    it('3つ以上のcreateContextも正しくマージされる', () => {
+      const module1: PromptModule<{ a: number }> = {
+        createContext: () => ({ a: 1 })
+      };
+      const module2: PromptModule<{ b: number }> = {
+        createContext: () => ({ b: 2 })
+      };
+      const module3: PromptModule<{ c: number }> = {
+        createContext: () => ({ c: 3 })
+      };
+      const result = merge(module1, module2, module3);
+      
+      expect(result.createContext!()).toEqual({ a: 1, b: 2, c: 3 });
+    });
+
+    it('どのモジュールにもcreateContextがない場合はundefined', () => {
+      const module1: PromptModule = {};
+      const module2: PromptModule = {};
+      const result = merge(module1, module2);
+      
+      expect(result.createContext).toBeUndefined();
+    });
+  });
+
+  describe('複数モジュールのマージ', () => {
+    it('3つ以上のモジュールをマージできる', () => {
+      const module1: PromptModule = { objective: ['目的1'] };
+      const module2: PromptModule = { objective: ['目的2'] };
+      const module3: PromptModule = { objective: ['目的3'] };
+      
+      const result = merge(module1, module2, module3);
+      
+      expect(result.objective).toEqual(['目的1', '目的2', '目的3']);
+    });
+
+    it('異なるセクションを持つ複数モジュールをマージできる', () => {
+      const module1: PromptModule = { 
+        objective: ['目的'],
+        processing: ['処理1']
+      };
+      const module2: PromptModule = { 
+        state: ['状態'],
+        processing: ['処理2']
+      };
+      const module3: PromptModule = { 
+        cue: ['出力'],
+        processing: ['処理3']
+      };
+      
+      const result = merge(module1, module2, module3);
+      
+      expect(result.objective).toEqual(['目的']);
+      expect(result.processing).toEqual(['処理1', '処理2', '処理3']);
+      expect(result.state).toEqual(['状態']);
+      expect(result.cue).toEqual(['出力']);
+    });
+  });
+
+  describe('順序の保持', () => {
+    it('通常要素 → サブセクションの順序が保持される', () => {
+      const module1: PromptModule = {
+        processing: [
+          {
+            type: 'subsection',
+            content: '',
+            title: 'サブ1',
+            items: ['項目1']
+          } as SubSectionElement,
+          '文字列1'
+        ]
+      };
+      const module2: PromptModule = {
+        processing: [
+          '文字列2',
+          {
+            type: 'subsection',
+            content: '',
+            title: 'サブ2',
+            items: ['項目2']
+          } as SubSectionElement
+        ]
+      };
+      const result = merge(module1, module2);
+      
+      // 期待される順序: 文字列1, 文字列2, サブ1, サブ2
+      expect(result.processing![0]).toBe('文字列1');
+      expect(result.processing![1]).toBe('文字列2');
+      expect((result.processing![2] as SubSectionElement).title).toBe('サブ1');
+      expect((result.processing![3] as SubSectionElement).title).toBe('サブ2');
+    });
+  });
+
+  describe('複雑な複数モジュールマージ', () => {
+    it('4つのモジュールで全機能を統合できる', () => {
+      const module1: PromptModule<{ a: string }> = {
+        createContext: () => ({ a: 'value1' }),
+        objective: ['目的1'],
+        instructions: [
+          '手順1-1',
+          {
+            type: 'subsection',
+            content: '',
+            title: 'アルゴリズム',
+            items: ['ステップ1']
+          } as SubSectionElement
+        ]
+      };
+
+      const module2: PromptModule<{ b: number }> = {
+        createContext: () => ({ b: 42 }),
+        objective: ['目的2'],
+        instructions: [
+          '手順2-1',
+          {
+            type: 'subsection',
+            content: '',
+            title: 'アルゴリズム',
+            items: ['ステップ2']
+          } as SubSectionElement
+        ],
+        state: ['状態2']
+      };
+
+      const module3: PromptModule<{ c: boolean }> = {
+        createContext: () => ({ c: true }),
+        objective: ['目的3'],
+        instructions: [
+          {
+            type: 'subsection',
+            content: '',
+            title: 'アルゴリズム',
+            items: ['ステップ3']
+          } as SubSectionElement,
+          {
+            type: 'subsection',
+            content: '',
+            title: '新しいセクション',
+            items: ['新規ステップ']
+          } as SubSectionElement
+        ],
+        cue: ['出力指示3']
+      };
+
+      const module4: PromptModule<{ d: string[] }> = {
+        createContext: () => ({ d: ['item1', 'item2'] }),
+        objective: ['目的4'],
+        instructions: [
+          '手順4-1',
+          (_context) => ({ type: 'text', content: 'Dynamic content' })
+        ],
+        materials: ['材料4'],
+        schema: ['スキーマ4']
+      };
+
+      const merged = merge(module1, module2, module3, module4);
+      
+      // createContextが全て統合されることを確認
+      const context = merged.createContext!();
+      expect(context).toEqual({
+        a: 'value1',
+        b: 42,
+        c: true,
+        d: ['item1', 'item2']
+      });
+
+      // objectiveが全て統合されることを確認
+      expect(merged.objective).toEqual(['目的1', '目的2', '目的3', '目的4']);
+
+      // instructionsが正しくマージされることを確認
+      expect(merged.instructions).toHaveLength(6); // 3つの通常要素 + 1つの動的要素 + 2つのサブセクション
+      expect(merged.instructions![0]).toBe('手順1-1');
+      expect(merged.instructions![1]).toBe('手順2-1');
+      expect(merged.instructions![2]).toBe('手順4-1');
+      expect(typeof merged.instructions![3]).toBe('function'); // Dynamic content
+      
+      // 同名サブセクションがマージされていることを確認
+      const algorithmSection = merged.instructions!.find(
+        item => typeof item === 'object' && item.type === 'subsection' && item.title === 'アルゴリズム'
+      ) as SubSectionElement;
+      expect(algorithmSection.items).toEqual(['ステップ1', 'ステップ2', 'ステップ3']);
+      
+      // 新しいサブセクションも含まれることを確認
+      const newSection = merged.instructions!.find(
+        item => typeof item === 'object' && item.type === 'subsection' && item.title === '新しいセクション'
+      ) as SubSectionElement;
+      expect(newSection.items).toEqual(['新規ステップ']);
+
+      // 他のセクションも正しくマージされることを確認
+      expect(merged.state).toEqual(['状態2']);
+      expect(merged.cue).toEqual(['出力指示3']);
+      expect(merged.materials).toEqual(['材料4']);
+      expect(merged.schema).toEqual(['スキーマ4']);
+    });
+
+    it('5つ以上のモジュールもマージできる', () => {
+      const modules: PromptModule[] = [
+        { objective: ['目的1'], terms: ['用語1'] },
+        { objective: ['目的2'], processing: ['処理2'] },
+        { objective: ['目的3'], instructions: ['手順3'] },
+        { objective: ['目的4'], guidelines: ['ガイド4'] },
+        { objective: ['目的5'], preparationNote: ['準備5'] },
+        { objective: ['目的6'], state: ['状態6'] }
+      ];
+
+      const merged = merge(...modules as [PromptModule, PromptModule, ...PromptModule[]]);
+      
+      expect(merged.objective).toEqual(['目的1', '目的2', '目的3', '目的4', '目的5', '目的6']);
+      expect(merged.terms).toEqual(['用語1']);
+      expect(merged.processing).toEqual(['処理2']);
+      expect(merged.instructions).toEqual(['手順3']);
+      expect(merged.guidelines).toEqual(['ガイド4']);
+      expect(merged.preparationNote).toEqual(['準備5']);
+      expect(merged.state).toEqual(['状態6']);
     });
   });
 });

--- a/packages/core/src/merge.ts
+++ b/packages/core/src/merge.ts
@@ -1,179 +1,123 @@
-/**
- * Merge functionality for PromptModules
- */
-
 import type {
   PromptModule,
-  ModuleContent,
-  Element,
-  SectionElement,
+  SectionContent,
   SubSectionElement,
   DynamicContent,
-  Context
-} from './types.js';
+  StandardSectionName
+} from './types';
+import { STANDARD_SECTIONS } from './types';
 
 /**
- * Merge multiple prompt modules into one
+ * 2つのPromptModuleをマージ
  */
-export function merge<T1 = Context, T2 = Context>(
+function mergeTwo<T1 = any, T2 = any>(
   module1: PromptModule<T1>,
   module2: PromptModule<T2>
-): PromptModule<T1 | T2>;
+): PromptModule<T1 & T2> {
+  const result: PromptModule<T1 & T2> = {};
 
-export function merge<T1 = Context, T2 = Context, T3 = Context>(
-  module1: PromptModule<T1>,
-  module2: PromptModule<T2>,
-  module3: PromptModule<T3>
-): PromptModule<T1 | T2 | T3>;
-
-export function merge(...modules: PromptModule<any>[]): PromptModule<any> {
-  if (modules.length === 0) {
-    return {};
-  }
+  // createContextをマージ（両方を実行して結果を統合）
+  const creators = [module1.createContext, module2.createContext].filter(c => c !== undefined);
   
-  if (modules.length === 1) {
-    return modules[0];
-  }
-  
-  const merged: PromptModule<any> = {};
-  
-  // Handle createContext - use the first one found
-  for (const module of modules) {
-    if (module.createContext && !merged.createContext) {
-      merged.createContext = module.createContext;
-      break;
-    }
-  }
-  
-  // Get all unique section names
-  const sectionNames = new Set<string>();
-  for (const module of modules) {
-    Object.keys(module).forEach(key => {
-      if (key !== 'createContext') {
-        sectionNames.add(key);
+  if (creators.length > 0) {
+    result.createContext = () => {
+      let mergedContext = {} as T1 & T2;
+      for (const creator of creators) {
+        const context = creator!();
+        mergedContext = { ...mergedContext, ...context } as T1 & T2;
       }
-    });
+      return mergedContext;
+    };
   }
-  
-  // Merge each section
+
+  // 各標準セクションをマージ
+  const sectionNames = Object.keys(STANDARD_SECTIONS) as StandardSectionName[];
+
   for (const sectionName of sectionNames) {
-    const sectionsToMerge: ModuleContent[] = [];
+    const sections = [module1[sectionName], module2[sectionName]].filter(s => s !== undefined);
     
-    for (const module of modules) {
-      if (module[sectionName]) {
-        sectionsToMerge.push(module[sectionName]);
-      }
-    }
-    
-    if (sectionsToMerge.length > 0) {
-      merged[sectionName] = mergeSections(...sectionsToMerge);
+    if (sections.length > 0) {
+      // 型の不一致を解決: 異なるContext型を統合
+      result[sectionName] = mergeSectionContents<T1 & T2>(...(sections as SectionContent<T1 & T2>[]));
     }
   }
-  
-  return merged;
+
+  return result;
 }
 
 /**
- * Merge multiple sections into one
+ * 複数のPromptModuleをマージ
  */
-function mergeSections(...sections: ModuleContent[]): ModuleContent {
-  if (sections.length === 0) {
-    return [];
+// 3つのモジュール
+export function merge<T1, T2, T3>(
+  ...modules: [PromptModule<T1>, PromptModule<T2>, PromptModule<T3>]
+): PromptModule<T1 & T2 & T3>;
+
+// 4つのモジュール
+export function merge<T1, T2, T3, T4>(
+  ...modules: [PromptModule<T1>, PromptModule<T2>, PromptModule<T3>, PromptModule<T4>]
+): PromptModule<T1 & T2 & T3 & T4>;
+
+// 5つのモジュール
+export function merge<T1, T2, T3, T4, T5>(
+  ...modules: [PromptModule<T1>, PromptModule<T2>, PromptModule<T3>, PromptModule<T4>, PromptModule<T5>]
+): PromptModule<T1 & T2 & T3 & T4 & T5>;
+
+// 6つのモジュール
+export function merge<T1, T2, T3, T4, T5, T6>(
+  ...modules: [PromptModule<T1>, PromptModule<T2>, PromptModule<T3>, PromptModule<T4>, PromptModule<T5>, PromptModule<T6>]
+): PromptModule<T1 & T2 & T3 & T4 & T5 & T6>;
+
+// 実装（2つ以上、デフォルト）
+export function merge<T1, T2>(
+  ...modules: [PromptModule<T1>, PromptModule<T2>, ...PromptModule<any>[]]
+): PromptModule<T1 & T2> {
+  // 2つずつマージを繰り返す
+  let result = mergeTwo(modules[0], modules[1]);
+  for (let i = 2; i < modules.length; i++) {
+    result = mergeTwo(result, modules[i]);
   }
-  
-  if (sections.length === 1) {
-    return sections[0];
-  }
-  
-  const merged: ModuleContent = [];
-  const subsectionMap = new Map<string, SubSectionElement>();
-  const sectionMap = new Map<string, SectionElement>();
-  const plainItems: (string | Element | DynamicContent)[] = [];
-  
-  // Classify and process all items
-  for (const section of sections) {
-    for (const item of section) {
+
+  return result;
+}
+
+/**
+ * 複数のセクションコンテンツをマージ
+ */
+function mergeSectionContents<TContext = any>(
+  ...contents: SectionContent<TContext>[]
+): SectionContent<TContext> {
+  const merged: SectionContent<TContext> = [];
+  const subsections = new Map<string, SubSectionElement>();
+  const plainItems: (string | DynamicContent<TContext>)[] = [];
+
+  // 全てのコンテンツを分類
+  for (const content of contents) {
+    for (const item of content) {
       if (typeof item === 'function') {
-        // DynamicContent - keep as is
+        // DynamicContentはそのまま保持
         plainItems.push(item);
       } else if (typeof item === 'string') {
-        // String - keep as is
+        // 文字列はそのまま保持
         plainItems.push(item);
-      } else if (typeof item === 'object' && 'type' in item) {
-        // Element
-        if (item.type === 'subsection') {
-          const existing = subsectionMap.get(item.title);
-          if (existing) {
-            // Merge subsections with same title
-            subsectionMap.set(item.title, {
-              ...item,
-              items: [...existing.items, ...item.items]
-            });
-          } else {
-            subsectionMap.set(item.title, item as SubSectionElement);
-          }
-        } else if (item.type === 'section') {
-          const existing = sectionMap.get(item.title);
-          if (existing) {
-            // Merge sections with same title
-            sectionMap.set(item.title, {
-              ...item,
-              items: mergeSubItems(existing.items, (item as SectionElement).items)
-            });
-          } else {
-            sectionMap.set(item.title, item as SectionElement);
-          }
+      } else if (item.type === 'subsection') {
+        // 同名のサブセクションをマージ
+        const existing = subsections.get(item.title);
+        if (existing) {
+          subsections.set(item.title, {
+            ...item,
+            items: [...existing.items, ...item.items]
+          });
         } else {
-          // Other elements
-          plainItems.push(item);
+          subsections.set(item.title, item);
         }
-      } else {
-        // Unknown - keep as is
-        plainItems.push(item);
       }
     }
   }
-  
-  // Combine in order: plain items → sections → subsections
-  merged.push(...plainItems);
-  merged.push(...Array.from(sectionMap.values()));
-  merged.push(...Array.from(subsectionMap.values()));
-  
-  return merged;
-}
 
-/**
- * Merge items within a SectionElement
- */
-function mergeSubItems(
-  items1: (string | SubSectionElement)[],
-  items2: (string | SubSectionElement)[]
-): (string | SubSectionElement)[] {
-  const merged: (string | SubSectionElement)[] = [];
-  const subsectionMap = new Map<string, SubSectionElement>();
-  const strings: string[] = [];
-  
-  // Process all items
-  for (const item of [...items1, ...items2]) {
-    if (typeof item === 'string') {
-      strings.push(item);
-    } else {
-      const existing = subsectionMap.get(item.title);
-      if (existing) {
-        // Merge subsection items
-        subsectionMap.set(item.title, {
-          ...item,
-          items: [...existing.items, ...item.items]
-        });
-      } else {
-        subsectionMap.set(item.title, item);
-      }
-    }
-  }
-  
-  // Order: strings → subsections
-  merged.push(...strings);
-  merged.push(...Array.from(subsectionMap.values()));
-  
+  // 結合順序: 通常要素 → サブセクション
+  merged.push(...plainItems);
+  merged.push(...Array.from(subsections.values()));
+
   return merged;
 }

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- 仕様の根本的な解釈違いを修正：標準セクションは自動的にSectionElementになる
- merge関数のContext型をユニオン型からインターセクション型（T1 & T2）に変更
- mergeTwo内部関数を実装してコードを整理

## Changes
### Type Safety Improvements
- TypeScriptオーバーロードを追加（最大6モジュール対応）
- タプル型を使用してコンパイル時に最小2モジュールを強制
- Context型をインターセクション型に変更（全モジュールの要件を満たす必要がある）

### Implementation Fixes
- createContextマージ：全ての関数を実行して結果をマージ
- 要素の順序を修正：通常要素→サブセクション
- STANDARD_SECTIONS定数を使用してDRY原則を守る

### Testing & Quality
- 3つ以上のモジュールをマージする包括的なテストを追加
- ESLint設定を追加して全てのLintエラーを修正
- 型チェックが成功することを確認

### Documentation
- API.md、GETTING_STARTED.md、CLAUDE.mdを追加
- 仕様書を更新して新しい実装を反映

## Breaking Changes
- `merge`は最小2モジュールが必要（型レベルで強制）
- Context型がユニオン型からインターセクション型に変更

## Test Plan
- [x] `npm test`：全29テストが成功
- [x] `npm run typecheck`：エラーなし
- [x] `npm run lint`：エラーなし

🤖 Generated with [Claude Code](https://claude.ai/code)