### PR TITLE
feat(driver): MLXドライバーの自動セットアップ機能を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2025-09-10
+
+### Added
+- **Driver Package**
+  - postinstallスクリプトによるMLXドライバーの自動セットアップ
+  - setup-mlxコマンドで手動セットアップ可能
+  - uvパッケージマネージャーの自動インストール
+
 ## [0.1.0] - 2025-09-10
 
 ### Added

--- a/packages/driver/README.md
+++ b/packages/driver/README.md
@@ -142,6 +142,29 @@ Ollamaドライバーは内部的にOpenAIドライバーを使用します（Ol
 
 Appleシリコン最適化モデル用のPythonベースのドライバー。
 
+#### セットアップ
+
+MLXドライバーは初回インストール時に自動的にPython環境をセットアップします：
+
+```bash
+npm install @moduler-prompt/driver
+# postinstallスクリプトが自動的にPython環境をセットアップ
+```
+
+手動セットアップが必要な場合：
+
+```bash
+cd node_modules/@moduler-prompt/driver
+npm run setup-mlx
+```
+
+**前提条件:**
+- Python 3.11以上
+- Apple Silicon Mac (M1/M2/M3)
+- uv（Pythonパッケージマネージャー、自動インストールされます）
+
+#### 使用方法
+
 ```typescript
 import { MlxDriver } from '@moduler-prompt/driver';
 
@@ -169,6 +192,7 @@ await driver.close();
 **注意事項:**
 - Pythonサブプロセスを使用するため、Python環境とMLXのインストールが必要
 - 使用後は必ず`close()`を呼び出してプロセスを終了
+- 初回実行時にモデルのダウンロードが発生する場合があります
 
 ### テストドライバー
 

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moduler-prompt/driver",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -15,7 +15,9 @@
     "test": "vitest",
     "test:run": "vitest run",
     "lint": "eslint src/**/*.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "postinstall": "node scripts/setup-mlx.js || true",
+    "setup-mlx": "node scripts/setup-mlx.js"
   },
   "dependencies": {
     "@moduler-prompt/core": "*",

--- a/packages/driver/scripts/setup-mlx.js
+++ b/packages/driver/scripts/setup-mlx.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pythonDir = join(__dirname, '..', 'src', 'mlx-ml', 'python');
+const distPythonDir = join(__dirname, '..', 'dist', 'mlx-ml', 'python');
+
+console.log('🚀 Setting up MLX driver dependencies...\n');
+
+// Check Python directory
+const targetDir = existsSync(distPythonDir) ? distPythonDir : pythonDir;
+
+if (!existsSync(targetDir)) {
+  console.log('⚠️  MLX Python directory not found. Skipping setup.');
+  console.log('   MLX driver will not be available.');
+  process.exit(0);
+}
+
+console.log(`📁 Working directory: ${targetDir}`);
+
+// Check if uv is installed
+try {
+  execSync('uv --version', { stdio: 'ignore' });
+  console.log('✅ uv is installed');
+} catch {
+  console.log('⚠️  uv is not installed. Installing uv...');
+  try {
+    execSync('curl -LsSf https://astral.sh/uv/install.sh | sh', { stdio: 'inherit' });
+    console.log('✅ uv installed successfully');
+  } catch (error) {
+    console.error('❌ Failed to install uv. Please install it manually:');
+    console.error('   curl -LsSf https://astral.sh/uv/install.sh | sh');
+    console.error('\n   MLX driver will not be available without uv.');
+    process.exit(0);
+  }
+}
+
+// Setup Python environment
+console.log('\n📦 Setting up Python environment...');
+try {
+  execSync('uv venv', { cwd: targetDir, stdio: 'inherit' });
+  execSync('uv pip install -e .', { cwd: targetDir, stdio: 'inherit' });
+  console.log('\n✅ MLX driver setup completed successfully!');
+  console.log('   You can now use MlxDriver from @moduler-prompt/driver');
+} catch (error) {
+  console.error('❌ Failed to setup Python environment:', error.message);
+  console.error('   MLX driver will not be available.');
+  process.exit(0);
+}


### PR DESCRIPTION
## 概要

MLXドライバーのPython環境を自動的にセットアップする機能を追加しました。

## 変更内容

### 自動セットアップ機能
- `postinstall`スクリプトでPython環境を自動構築
- `npm install @moduler-prompt/driver`実行時に自動的にMLX環境をセットアップ
- 失敗してもパッケージインストールは続行（MLX以外のドライバーは使用可能）

### 手動セットアップコマンド
- `npm run setup-mlx`コマンドで手動セットアップが可能
- 自動セットアップが失敗した場合の代替手段

### セットアップスクリプト
- uvパッケージマネージャーの自動インストール
- Python仮想環境の作成
- 必要な依存関係のインストール

### ドキュメント更新
- READMEにMLXドライバーのセットアップ手順を詳細に記載
- 前提条件と手動セットアップ方法を明記

## 動作要件

- Python 3.11以上
- Apple Silicon Mac (M1/M2/M3)
- uv（自動インストールされます）

## テスト

- [x] postinstallスクリプトの動作確認
- [x] 手動セットアップコマンドの動作確認
- [x] エラーハンドリングの確認

🤖 Generated with [Claude Code](https://claude.ai/code)